### PR TITLE
V2.20

### DIFF
--- a/2.19ReadMe
+++ b/2.19ReadMe
@@ -1,5 +1,0 @@
-#Version 2.19 5-Apr-2018
-#	Added Event Log information to each domain controller and an appendix
-#		If the script is run from an elevated PowerShell session by a user with Domain Admin rights
-#	Added Operating System information to Functions GetComputerWMIInfo and OutputComputerItem
-#	Code clean-up for most recommendations made by Visual Studio Code

--- a/2.20ReadMe
+++ b/2.20ReadMe
@@ -1,14 +1,23 @@
-#Version 2.20
+#Version 2.20 28-Sep-2018
 #	Added Domain Functional Level of 7 for Windows Server 2016
 #	Added Forest Functional Level of 7 for Windows Server 2016
 #	Added Domain Schema version 88 for Server 2019 Preview
 #	Added to Domain Information:
 #		Last logon replication interval
 #		Public key required password rolling (2012+)
+#	Added to Forest Information, Domain Controllers:
+#		Operation System
+#		Server Core (Y/N)
 #	Changed "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
 #	Changed all but the Word and HTML arrays from "@() +=" to "New-Object System.Collections.ArrayList .Add()"
 #	Changed the code where I checked for Singletons and -is [array] to use @() around the cmdlets so the result
 #		is always an array. Thanks to fellow CTP Sam Jacobs for the tip. This reduced the code by almost 500 lines.
+#	Changed the functions getting the computer WMI hardware and service info to use 
+#		"New-Object System.Collections.ArrayList .Add()" for Word and HTML tables
+#	Changed the width of the Domain Controllers table to accommodate the new columns
+#	Change the width of the AD Schema Items table to match the other tables
 #	Remove all the duplicate $VarName = $Null from Function ProcessDomains
+#	Reorder Change Log so the most recent is on top and the oldest is at the bottom
 #	Reorder most of the domain properties to be in alphabetical order
 #	Reorder most of the forest properties to be in alphabetical order
+#	Updated Exchange schema version information

--- a/2.20ReadMe
+++ b/2.20ReadMe
@@ -1,5 +1,14 @@
 #Version 2.20
 #	Added Domain Functional Level of 7 for Windows Server 2016
 #	Added Forest Functional Level of 7 for Windows Server 2016
-#	Change "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
-#	
+#	Added Domain Schema version 88 for Server 2019 Preview
+#	Added to Domain Information:
+#		Last logon replication interval
+#		Public key required password rolling (2012+)
+#	Changed "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
+#	Changed all but the Word and HTML arrays from "@() +=" to "New-Object System.Collections.ArrayList .Add()"
+#	Changed the code where I checked for Singletons and -is [array] to use @() around the cmdlets so the result
+#		is always an array. Thanks to fellow CTP Sam Jacobs for the tip. This reduced the code by almost 500 lines.
+#	Remove all the duplicate $VarName = $Null from Function ProcessDomains
+#	Reorder most of the domain properties to be in alphabetical order
+#	Reorder most of the forest properties to be in alphabetical order

--- a/2.20ReadMe
+++ b/2.20ReadMe
@@ -1,0 +1,5 @@
+#Version 2.20
+#	Added Domain Functional Level of 7 for Windows Server 2016
+#	Added Forest Functional Level of 7 for Windows Server 2016
+#	Change "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
+#	

--- a/ADDS_Inventory_V2.ps1
+++ b/ADDS_Inventory_V2.ps1
@@ -804,7 +804,7 @@
 	NAME: ADDS_Inventory_V2.ps1
 	VERSION: 2.20
 	AUTHOR: Carl Webster, Sr. Solutions Architect, Choice Solutions, LLC and Michael B. Smith
-	LASTEDIT: April 28, 2018
+	LASTEDIT: September 28, 2018
 #>
 
 
@@ -953,6 +953,143 @@ Param(
 #Version 1.0 released to the community on May 31, 2014
 #
 #Version 2.0 is based on version 1.20
+#
+#Version 2.20 28-Sep-2018
+#	Added Domain Functional Level of 7 for Windows Server 2016
+#	Added Forest Functional Level of 7 for Windows Server 2016
+#	Added Domain Schema version 88 for Server 2019 Preview
+#	Added to Domain Information:
+#		Last logon replication interval
+#		Public key required password rolling (2012+)
+#	Added to Forest Information, Domain Controllers:
+#		Operation System
+#		Server Core (Y/N)
+#	Changed "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
+#	Changed all but the Word and HTML arrays from "@() +=" to "New-Object System.Collections.ArrayList .Add()"
+#	Changed the code where I checked for Singletons and -is [array] to use @() around the cmdlets so the result
+#		is always an array. Thanks to fellow CTP Sam Jacobs for the tip. This reduced the code by almost 500 lines.
+#	Changed the functions getting the computer WMI hardware and service info to use 
+#		"New-Object System.Collections.ArrayList .Add()" for Word and HTML tables
+#	Changed the width of the Domain Controllers table to accommodate the new columns
+#	Change the width of the AD Schema Items table to match the other tables
+#	Remove all the duplicate $VarName = $Null from Function ProcessDomains
+#	Reorder Change Log so the most recent is on top and the oldest is at the bottom
+#	Reorder most of the domain properties to be in alphabetical order
+#	Reorder most of the forest properties to be in alphabetical order
+#	Updated Exchange schema version information
+#
+#Version 2.19 5-Apr-2018
+#	Added Event Log information to each domain controller and an appendix
+#		If the script is run from an elevated PowerShell session by a user with Domain Admin rights
+#	Added Operating System information to Functions GetComputerWMIInfo and OutputComputerItem
+#	Code clean-up for most recommendations made by Visual Studio Code
+#
+#Version 2.18 10-Mar-2018
+#	Added Log switch to create a transcript log
+#
+#Version 2.17 8-Dec-2017
+#	Updated Function WriteHTMLLine with fixes from the script template
+#
+#Version 2.16 4-Dec-2017
+#	Add checking for users with home drive set in Active Directory Users and Computers (ADUC)
+#		Added function OutputHDUserInfo
+#	Add checking for users with RDS home drive set in ADUC
+#		Added function from Jeff Hicks Get-RDUserSetting
+#		Added function OutputRDSHDUserInfo
+#	Add checking for users whose Primary Group is not Domain Users
+#		Added function OutputPGUserInfo
+#	Add "DC: " in fron tof the domain controller name, in text output, for domain controller information
+#	Add new parameter ADDomain to restrict report to a single domain in a multi-domain Forest
+#	Add schema extension checking for the following items and add to Forest section:
+#		'User-Account-Control', #Flags that control the behavior of a user account
+#		'msNPAllowDialin', #RAS Server
+#		'ms-Mcs-AdmPwd', #LAPS
+#		'ms-Mcs-AdmPwdExpirationTime', #LAPS
+#		'ms-SMS-Assignment-Site-Code', #SCCM
+#		'ms-SMS-Capabilities', #SCCM
+#		'msRTCSIP-UserRoutingGroupId', #Lync/SfB
+#		'msRTCSIP-MirrorBackEndServer' #Lync/SfB
+#		'ms-exch-schema-version-pt' #Exchange
+#	Add "Site: " in front of Site name when listing Subnets, Servers, and Connection Objects
+#	Remove several large blocks of code that had been commented out
+#	Revise how $LinkedGPOs and $InheritedGPOs variables are set to work around invalid property 
+#		name DisplayName when collection is empty
+#	Sort Enabled Scopes in AD Optional Features
+#	Text output changes to tabular data:
+#		Domain Controllers (in Forest section)
+#		AD Schema Items (in Forest section)
+#		Services
+#		Organizational Units
+#		Domain Admins
+#		Enterprise Admins
+#		Schema Admins
+#		Users with AdminCount=1
+#	Updated Exchange schema versions
+#	Updated help text
+#	When reporting on the domain controllers in the Forest, if unable to get data from a domain controller,
+#		instead of reporting "Unknown", use:
+#		Unable to retrieve Global Catalog status on <DCName>
+#		Unable to retrieve Read-only status on <DCName>
+#	When run for a single domain in a multi-domain forest
+#		Revise gathering list of domains
+#		Revise testing for $ComputerName 
+#		Revise variable $ADContext in Function ProcessAllDCsInTheForest
+#
+#Version 2.15 26-Jun-2017
+#	Added new parameter MaxDetails:
+#		This is the same as using the following parameters:
+#			DCDNSInfo
+#			GPOInheritance
+#			HardWare
+#			IncludeUserInfo
+#			Services
+#	Fixed wrong loop variable for CA
+#	Removed code that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
+#	Reordered the parameters in the help text and parameter list so they match and are grouped better
+#	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
+#	Updated Function ProcessScriptEnd for the new Cover Page properties and Parameters
+#	Updated Function ShowScriptOptions for the new Cover Page properties and Parameters
+#	Updated Function UpdateDocumentProperties for the new Cover Page properties and Parameters
+#	Updated help text
+#
+#Version 2.14 12-May-2017
+#	Add Certificate Authority Information section to Forest Information
+#		Check for the following CA related errors:
+#			Possible error: There are more than one Certification Authority Root(s)
+#			Error: Certification Authority Root(s) exist, but no Certification Authority Issuers(s) (also known as Enrollment Agents) exist
+#			Error: More Certification Authority Root(s) exist than there are Certification Authority Issuers(s) (also known as Enrollment Agents)
+#			Error: Certification Authority Issuers(s) (also known as Enrollment Agents) exist, but no Certification Authority Root(s) exist
+#	Change "Users with AdminCount=1 ($($AdminsCountStr) members):" to "Users with AdminCount=1 ($($AdminsCountStr) users):"
+#	Reorder the Forest Information section
+#
+#Version 2.13 13-Feb-2017
+#	Fix French wording for Table of Contents 2
+#
+#Version 2.12 10-Nov-2016
+#	Add Chinese language support
+#	Add table for Time Server information if script is run from an elevated PowerShell session
+#	Remove "Appendix A" from DC DNS Info table
+#
+#Version 2.11 6-Nov-2016
+#	Fixed Domain Trust Attributes (thanks GT)
+#	Fixed several Write-Warning statements that had no message
+#	Fixed using -AddDateTime with -HTML
+#	Remove duplicate setting for $Script:Title
+#	Reworked the use of [gc]::Collect()
+#
+#Version 2.10 released on 19-Oct-2016 (Happy Birthday Linz)
+#	Add a new parameter, IncludeUserInfo
+#		Add to the User Miscellaneous Data section, outputs a table with the SamAccountName
+#		and DistinguishedName of the users in the All Users counts
+#	Add to the Domain section, listing Fine Grained Password Policies
+#	Add to the Forest section, Tombstone Lifetime
+#	Changed the HTML header for AD Optional Features from a table header to a section header
+#	Changed "Site and Services" heading to "Sites and Services"
+#	Fixed formatting issues with HTML headings output
+#	The $AdminsCountStr variable was used, when it should not have been used, 
+#		when privileged groups had no members or members could not be retrieved
+#	Update Forest and Domain schema tables for the released Server 2016 product
+#
 #Version 2.0 released 26-Sep-2016
 #
 #	Added a parameter, GPOInheritance, to set whether to use the new GPOs by OU with linked and inherited GPOs
@@ -1003,132 +1140,7 @@ Param(
 #	Update Verbose messages for testing to see if -ComputerName is a domain controller
 #	Worked around Get-ADDomainController issue when run from a child domain
 #
-#Version 2.10 released on 19-Oct-2016 (Happy Birthday Linz)
-#	Add a new parameter, IncludeUserInfo
-#		Add to the User Miscellaneous Data section, outputs a table with the SamAccountName
-#		and DistinguishedName of the users in the All Users counts
-#	Add to the Domain section, listing Fine Grained Password Policies
-#	Add to the Forest section, Tombstone Lifetime
-#	Changed the HTML header for AD Optional Features from a table header to a section header
-#	Changed "Site and Services" heading to "Sites and Services"
-#	Fixed formatting issues with HTML headings output
-#	The $AdminsCountStr variable was used, when it should not have been used, 
-#		when privileged groups had no members or members could not be retrieved
-#	Update Forest and Domain schema tables for the released Server 2016 product
-#
-#Version 2.11 6-Nov-2016
-#	Fixed Domain Trust Attributes (thanks GT)
-#	Fixed several Write-Warning statements that had no message
-#	Fixed using -AddDateTime with -HTML
-#	Remove duplicate setting for $Script:Title
-#	Reworked the use of [gc]::Collect()
-#
-#Version 2.12
-#	Add Chinese language support
-#	Add table for Time Server information if script is run from an elevated PowerShell session
-#	Remove "Appendix A" from DC DNS Info table
-#
-#Version 2.13
-#	Fix French wording for Table of Contents 2
-#
-#Version 2.14
-#	Add Certificate Authority Information section to Forest Information
-#		Check for the following CA related errors:
-#			Possible error: There are more than one Certification Authority Root(s)
-#			Error: Certification Authority Root(s) exist, but no Certification Authority Issuers(s) (also known as Enrollment Agents) exist
-#			Error: More Certification Authority Root(s) exist than there are Certification Authority Issuers(s) (also known as Enrollment Agents)
-#			Error: Certification Authority Issuers(s) (also known as Enrollment Agents) exist, but no Certification Authority Root(s) exist
-#	Change "Users with AdminCount=1 ($($AdminsCountStr) members):" to "Users with AdminCount=1 ($($AdminsCountStr) users):"
-#	Reorder the Forest Information section
-#
-#Version 2.15
-#	Added new parameter MaxDetails:
-#		This is the same as using the following parameters:
-#			DCDNSInfo
-#			GPOInheritance
-#			HardWare
-#			IncludeUserInfo
-#			Services
-#	Fixed wrong loop variable for CA
-#	Removed code that made sure all Parameters were set to default values if for some reason they did exist or values were $Null
-#	Reordered the parameters in the help text and parameter list so they match and are grouped better
-#	Replaced _SetDocumentProperty function with Jim Moyle's Set-DocumentProperty function
-#	Updated Function ProcessScriptEnd for the new Cover Page properties and Parameters
-#	Updated Function ShowScriptOptions for the new Cover Page properties and Parameters
-#	Updated Function UpdateDocumentProperties for the new Cover Page properties and Parameters
-#	Updated help text
-#
-#Version 2.16 4-Dec-2017
-#	Add checking for users with home drive set in Active Directory Users and Computers (ADUC)
-#		Added function OutputHDUserInfo
-#	Add checking for users with RDS home drive set in ADUC
-#		Added function from Jeff Hicks Get-RDUserSetting
-#		Added function OutputRDSHDUserInfo
-#	Add checking for users whose Primary Group is not Domain Users
-#		Added function OutputPGUserInfo
-#	Add "DC: " in fron tof the domain controller name, in text output, for domain controller information
-#	Add new parameter ADDomain to restrict report to a single domain in a multi-domain Forest
-#	Add schema extension checking for the following items and add to Forest section:
-#		'User-Account-Control', #Flags that control the behavior of a user account
-#		'msNPAllowDialin', #RAS Server
-#		'ms-Mcs-AdmPwd', #LAPS
-#		'ms-Mcs-AdmPwdExpirationTime', #LAPS
-#		'ms-SMS-Assignment-Site-Code', #SCCM
-#		'ms-SMS-Capabilities', #SCCM
-#		'msRTCSIP-UserRoutingGroupId', #Lync/SfB
-#		'msRTCSIP-MirrorBackEndServer' #Lync/SfB
-#		'ms-exch-schema-version-pt' #Exchange
-#	Add "Site: " in front of Site name when listing Subnets, Servers, and Connection Objects
-#	Remove several large blocks of code that had been commented out
-#	Revise how $LinkedGPOs and $InheritedGPOs variables are set to work around invalid property 
-#		name DisplayName when collection is empty
-#	Sort Enabled Scopes in AD Optional Features
-#	Text output changes to tabular data:
-#		Domain Controllers (in Forest section)
-#		AD Schema Items (in Forest section)
-#		Services
-#		Organizational Units
-#		Domain Admins
-#		Enterprise Admins
-#		Schema Admins
-#		Users with AdminCount=1
-#	Updated Exchange schema versions
-#	Updated help text
-#	When reporting on the domain controllers in the Forest, if unable to get data from a domain controller,
-#		instead of reporting "Unknown", use:
-#		Unable to retrieve Global Catalog status on <DCName>
-#		Unable to retrieve Read-only status on <DCName>
-#	When run for a single domain in a multi-domain forest
-#		Revise gathering list of domains
-#		Revise testing for $ComputerName 
-#		Revise variable $ADContext in Function ProcessAllDCsInTheForest
-#
-#Version 2.17 8-Dec-2017
-#	Updated Function WriteHTMLLine with fixes from the script template
-#
-#Version 2.18 10-Mar-2018
-#	Added Log switch to create a transcript log
-#
-#Version 2.19 5-Apr-2018
-#	Added Event Log information to each domain controller and an appendix
-#		If the script is run from an elevated PowerShell session by a user with Domain Admin rights
-#	Added Operating System information to Functions GetComputerWMIInfo and OutputComputerItem
-#	Code clean-up for most recommendations made by Visual Studio Code
-#
-#Version 2.20
-#	Added Domain Functional Level of 7 for Windows Server 2016
-#	Added Forest Functional Level of 7 for Windows Server 2016
-#	Added Domain Schema version 88 for Server 2019 Preview
-#	Added to Domain Information:
-#		Last logon replication interval
-#		Public key required password rolling (2012+)
-#	Changed "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
-#	Changed all but the Word and HTML arrays from "@() +=" to "New-Object System.Collections.ArrayList .Add()"
-#	Changed the code where I checked for Singletons and -is [array] to use @() around the cmdlets so the result
-#		is always an array. Thanks to fellow CTP Sam Jacobs for the tip. This reduced the code by almost 500 lines.
-#	Remove all the duplicate $VarName = $Null from Function ProcessDomains
-#	Reorder most of the domain properties to be in alphabetical order
-#	Reorder most of the forest properties to be in alphabetical order
+
 
 Set-StrictMode -Version 2
 
@@ -1517,7 +1529,7 @@ Function GetComputerWMIInfo
 	# http://blog.myvirtualvision.com
 	# modified 1-May-2014 to work in trusted AD Forests and using different domain admin credentials	
 	# modified 17-Aug-2016 to fix a few issues with Text and HTML output
-	# modified 2-Aug-2018 to add ComputerOS information
+	# modified 29-Apr-2018 to change from Arrays to New-Object System.Collections.ArrayList
 
 	#Get Computer info
 	Write-Verbose "$(Get-Date): `t`tProcessing WMI Computer information"
@@ -1947,18 +1959,17 @@ Function GetComputerWMIInfo
 Function OutputComputerItem
 {
 	Param([object]$Item, [string]$OS)
-	# modified 2-Aug-2018 to add Operating System information
 	
 	If($MSWord -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $ItemInformation = @()
-		$ItemInformation += @{ Data = "Manufacturer"; Value = $Item.manufacturer; }
-		$ItemInformation += @{ Data = "Model"; Value = $Item.model; }
-		$ItemInformation += @{ Data = "Domain"; Value = $Item.domain; }
-		$ItemInformation += @{ Data = "Operating System"; Value = $OS; }
-		$ItemInformation += @{ Data = "Total Ram"; Value = "$($Item.totalphysicalram) GB"; }
-		$ItemInformation += @{ Data = "Physical Processors (sockets)"; Value = $Item.NumberOfProcessors; }
-		$ItemInformation += @{ Data = "Logical Processors (cores w/HT)"; Value = $Item.NumberOfLogicalProcessors; }
+		$ItemInformation = New-Object System.Collections.ArrayList
+		$ItemInformation.Add(@{ Data = "Manufacturer"; Value = $Item.manufacturer; }) > $Null
+		$ItemInformation.Add(@{ Data = "Model"; Value = $Item.model; }) > $Null
+		$ItemInformation.Add(@{ Data = "Domain"; Value = $Item.domain; }) > $Null
+		$ItemInformation.Add(@{ Data = "Operating System"; Value = $OS; }) > $Null
+		$ItemInformation.Add(@{ Data = "Total Ram"; Value = "$($Item.totalphysicalram) GB"; }) > $Null
+		$ItemInformation.Add(@{ Data = "Physical Processors (sockets)"; Value = $Item.NumberOfProcessors; }) > $Null
+		$ItemInformation.Add(@{ Data = "Logical Processors (cores w/HT)"; Value = $Item.NumberOfLogicalProcessors; }) > $Null
 		$Table = AddWordTable -Hashtable $ItemInformation `
 		-Columns Data,Value `
 		-List `
@@ -1990,14 +2001,14 @@ Function OutputComputerItem
 	}
 	ElseIf($HTML)
 	{
-		$rowdata = @()
+		$rowdata = New-Object System.Collections.ArrayList
 		$columnHeaders = @("Manufacturer",($htmlsilver -bor $htmlbold),$Item.manufacturer,$htmlwhite)
-		$rowdata += @(,('Model',($htmlsilver -bor $htmlbold),$Item.model,$htmlwhite))
-		$rowdata += @(,('Domain',($htmlsilver -bor $htmlbold),$Item.domain,$htmlwhite))
-		$rowdata += @(,('Operating System',($htmlsilver -bor $htmlbold),$OS,$htmlwhite))
-		$rowdata += @(,('Total Ram',($htmlsilver -bor $htmlbold),"$($Item.totalphysicalram) GB",$htmlwhite))
-		$rowdata += @(,('Physical Processors (sockets)',($htmlsilver -bor $htmlbold),$Item.NumberOfProcessors,$htmlwhite))
-		$rowdata += @(,('Logical Processors (cores w/HT)',($htmlsilver -bor $htmlbold),$Item.NumberOfLogicalProcessors,$htmlwhite))
+		$rowdata.Add(@(,('Model',($htmlsilver -bor $htmlbold),$Item.model,$htmlwhite))) > $Null
+		$rowdata.Add(@(,('Domain',($htmlsilver -bor $htmlbold),$Item.domain,$htmlwhite))) > $Null
+		$rowdata.Add(@(,('Operating System',($htmlsilver -bor $htmlbold),$OS,$htmlwhite))) > $Null
+		$rowdata.Add(@(,('Total Ram',($htmlsilver -bor $htmlbold),"$($Item.totalphysicalram) GB",$htmlwhite))) > $Null
+		$rowdata.Add(@(,('Physical Processors (sockets)',($htmlsilver -bor $htmlbold),$Item.NumberOfProcessors,$htmlwhite))) > $Null
+		$rowdata.Add(@(,('Logical Processors (cores w/HT)',($htmlsilver -bor $htmlbold),$Item.NumberOfLogicalProcessors,$htmlwhite))) > $Null
 
 		$msg = ""
 		$columnWidths = @("150px","200px")
@@ -2038,27 +2049,27 @@ Function OutputDriveItem
 
 	If($MSWORD -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $DriveInformation = @()
-		$DriveInformation += @{ Data = "Caption"; Value = $Drive.caption; }
-		$DriveInformation += @{ Data = "Size"; Value = "$($drive.drivesize) GB"; }
+		$DriveInformation = New-Object System.Collections.ArrayList
+		$DriveInformation.Add(@{ Data = "Caption"; Value = $Drive.caption; }) > $Null
+		$DriveInformation.Add(@{ Data = "Size"; Value = "$($drive.drivesize) GB"; }) > $Null
 		If(![String]::IsNullOrEmpty($drive.filesystem))
 		{
-			$DriveInformation += @{ Data = "File System"; Value = $Drive.filesystem; }
+			$DriveInformation.Add(@{ Data = "File System"; Value = $Drive.filesystem; }) > $Null
 		}
-		$DriveInformation += @{ Data = "Free Space"; Value = "$($drive.drivefreespace) GB"; }
+		$DriveInformation.Add(@{ Data = "Free Space"; Value = "$($drive.drivefreespace) GB"; }) > $Null
 		If(![String]::IsNullOrEmpty($drive.volumename))
 		{
-			$DriveInformation += @{ Data = "Volume Name"; Value = $Drive.volumename; }
+			$DriveInformation.Add(@{ Data = "Volume Name"; Value = $Drive.volumename; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($drive.volumedirty))
 		{
-			$DriveInformation += @{ Data = "Volume is Dirty"; Value = $xVolumeDirty; }
+			$DriveInformation.Add(@{ Data = "Volume is Dirty"; Value = $xVolumeDirty; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($drive.volumeserialnumber))
 		{
-			$DriveInformation += @{ Data = "Volume Serial Number"; Value = $Drive.volumeserialnumber; }
+			$DriveInformation.Add(@{ Data = "Volume Serial Number"; Value = $Drive.volumeserialnumber; }) > $Null
 		}
-		$DriveInformation += @{ Data = "Drive Type"; Value = $xDriveType; }
+		$DriveInformation.Add(@{ Data = "Drive Type"; Value = $xDriveType; }) > $Null
 		$Table = AddWordTable -Hashtable $DriveInformation `
 		-Columns Data,Value `
 		-List `
@@ -2105,33 +2116,33 @@ Function OutputDriveItem
 	}
 	ElseIf($HTML)
 	{
-		$rowdata = @()
+		$rowdata = New-Object System.Collections.ArrayList
 		$columnHeaders = @("Caption",($htmlsilver -bor $htmlbold),$Drive.caption,$htmlwhite)
-		$rowdata += @(,('Size',($htmlsilver -bor $htmlbold),"$($drive.drivesize) GB",$htmlwhite))
+		$rowdata.Add(@(,('Size',($htmlsilver -bor $htmlbold),"$($drive.drivesize) GB",$htmlwhite))) > $Null
 
 		If(![String]::IsNullOrEmpty($drive.filesystem))
 		{
-			$rowdata += @(,('File System',($htmlsilver -bor $htmlbold),$Drive.filesystem,$htmlwhite))
+			$rowdata.Add(@(,('File System',($htmlsilver -bor $htmlbold),$Drive.filesystem,$htmlwhite))) > $Null
 		}
-		$rowdata += @(,('Free Space',($htmlsilver -bor $htmlbold),"$($drive.drivefreespace) GB",$htmlwhite))
+		$rowdata.Add(@(,('Free Space',($htmlsilver -bor $htmlbold),"$($drive.drivefreespace) GB",$htmlwhite))) > $Null
 		If(![String]::IsNullOrEmpty($drive.volumename))
 		{
-			$rowdata += @(,('Volume Name',($htmlsilver -bor $htmlbold),$Drive.volumename,$htmlwhite))
+			$rowdata.Add(@(,('Volume Name',($htmlsilver -bor $htmlbold),$Drive.volumename,$htmlwhite))) > $Null
 		}
 		If(![String]::IsNullOrEmpty($drive.volumedirty))
 		{
-			$rowdata += @(,('Volume is Dirty',($htmlsilver -bor $htmlbold),$xVolumeDirty,$htmlwhite))
+			$rowdata.Add(@(,('Volume is Dirty',($htmlsilver -bor $htmlbold),$xVolumeDirty,$htmlwhite))) > $Null
 		}
 		If(![String]::IsNullOrEmpty($drive.volumeserialnumber))
 		{
-			$rowdata += @(,('Volume Serial Number',($htmlsilver -bor $htmlbold),$Drive.volumeserialnumber,$htmlwhite))
+			$rowdata.Add(@(,('Volume Serial Number',($htmlsilver -bor $htmlbold),$Drive.volumeserialnumber,$htmlwhite))) > $Null
 		}
-		$rowdata += @(,('Drive Type',($htmlsilver -bor $htmlbold),$xDriveType,$htmlwhite))
+		$rowdata.Add(@(,('Drive Type',($htmlsilver -bor $htmlbold),$xDriveType,$htmlwhite))) > $Null
 
 		$msg = ""
 		$columnWidths = @("150px","200px")
-		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
-		WriteHTMLLine 0 0 " "
+		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths
+		WriteHTMLLine 0 0 ""
 	}
 }
 
@@ -2164,27 +2175,27 @@ Function OutputProcessorItem
 
 	If($MSWORD -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $ProcessorInformation = @()
-		$ProcessorInformation += @{ Data = "Name"; Value = $Processor.name; }
-		$ProcessorInformation += @{ Data = "Description"; Value = $Processor.description; }
-		$ProcessorInformation += @{ Data = "Max Clock Speed"; Value = "$($processor.maxclockspeed) MHz"; }
+		$ProcessorInformation = New-Object System.Collections.ArrayList
+		$ProcessorInformation.Add(@{ Data = "Name"; Value = $Processor.name; }) > $Null
+		$ProcessorInformation.Add(@{ Data = "Description"; Value = $Processor.description; }) > $Null
+		$ProcessorInformation.Add(@{ Data = "Max Clock Speed"; Value = "$($processor.maxclockspeed) MHz"; }) > $Null
 		If($processor.l2cachesize -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "L2 Cache Size"; Value = "$($processor.l2cachesize) KB"; }
+			$ProcessorInformation.Add(@{ Data = "L2 Cache Size"; Value = "$($processor.l2cachesize) KB"; }) > $Null
 		}
 		If($processor.l3cachesize -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "L3 Cache Size"; Value = "$($processor.l3cachesize) KB"; }
+			$ProcessorInformation.Add(@{ Data = "L3 Cache Size"; Value = "$($processor.l3cachesize) KB"; }) > $Null
 		}
 		If($processor.numberofcores -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "Number of Cores"; Value = $Processor.numberofcores; }
+			$ProcessorInformation.Add(@{ Data = "Number of Cores"; Value = $Processor.numberofcores; }) > $Null
 		}
 		If($processor.numberoflogicalprocessors -gt 0)
 		{
-			$ProcessorInformation += @{ Data = "Number of Logical Processors (cores w/HT)"; Value = $Processor.numberoflogicalprocessors; }
+			$ProcessorInformation.Add(@{ Data = "Number of Logical Processors (cores w/HT)"; Value = $Processor.numberoflogicalprocessors; }) > $Null
 		}
-		$ProcessorInformation += @{ Data = "Availability"; Value = $xAvailability; }
+		$ProcessorInformation.Add(@{ Data = "Availability"; Value = $xAvailability; }) > $Null
 		$Table = AddWordTable -Hashtable $ProcessorInformation `
 		-Columns Data,Value `
 		-List `
@@ -2229,33 +2240,33 @@ Function OutputProcessorItem
 	}
 	ElseIf($HTML)
 	{
-		$rowdata = @()
+		$rowdata = New-Object System.Collections.ArrayList
 		$columnHeaders = @("Name",($htmlsilver -bor $htmlbold),$Processor.name,$htmlwhite)
-		$rowdata += @(,('Description',($htmlsilver -bor $htmlbold),$Processor.description,$htmlwhite))
+		$rowdata.Add(@(,('Description',($htmlsilver -bor $htmlbold),$Processor.description,$htmlwhite))) > $Null
 
-		$rowdata += @(,('Max Clock Speed',($htmlsilver -bor $htmlbold),"$($processor.maxclockspeed) MHz",$htmlwhite))
+		$rowdata.Add(@(,('Max Clock Speed',($htmlsilver -bor $htmlbold),"$($processor.maxclockspeed) MHz",$htmlwhite))) > $Null
 		If($processor.l2cachesize -gt 0)
 		{
-			$rowdata += @(,('L2 Cache Size',($htmlsilver -bor $htmlbold),"$($processor.l2cachesize) KB",$htmlwhite))
+			$rowdata.Add(@(,('L2 Cache Size',($htmlsilver -bor $htmlbold),"$($processor.l2cachesize) KB",$htmlwhite))) > $Null
 		}
 		If($processor.l3cachesize -gt 0)
 		{
-			$rowdata += @(,('L3 Cache Size',($htmlsilver -bor $htmlbold),"$($processor.l3cachesize) KB",$htmlwhite))
+			$rowdata.Add(@(,('L3 Cache Size',($htmlsilver -bor $htmlbold),"$($processor.l3cachesize) KB",$htmlwhite))) > $Null
 		}
 		If($processor.numberofcores -gt 0)
 		{
-			$rowdata += @(,('Number of Cores',($htmlsilver -bor $htmlbold),$Processor.numberofcores,$htmlwhite))
+			$rowdata.Add(@(,('Number of Cores',($htmlsilver -bor $htmlbold),$Processor.numberofcores,$htmlwhite))) > $Null
 		}
 		If($processor.numberoflogicalprocessors -gt 0)
 		{
-			$rowdata += @(,('Number of Logical Processors (cores w/HT)',($htmlsilver -bor $htmlbold),$Processor.numberoflogicalprocessors,$htmlwhite))
+			$rowdata.Add(@(,('Number of Logical Processors (cores w/HT)',($htmlsilver -bor $htmlbold),$Processor.numberoflogicalprocessors,$htmlwhite))) > $Null
 		}
-		$rowdata += @(,('Availability',($htmlsilver -bor $htmlbold),$xAvailability,$htmlwhite))
+		$rowdata.Add(@(,('Availability',($htmlsilver -bor $htmlbold),$xAvailability,$htmlwhite))) > $Null
 
 		$msg = ""
 		$columnWidths = @("150px","200px")
-		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
-		WriteHTMLLine 0 0 " "
+		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths
+		WriteHTMLLine 0 0 ""
 	}
 }
 
@@ -2304,35 +2315,35 @@ Function OutputNicItem
 		Default	{$xAvailability = "Unknown"; Break}
 	}
 
-	$xIPAddress = @()
+	$xIPAddress = New-Object System.Collections.ArrayList
 	ForEach($IPAddress in $Nic.ipaddress)
 	{
-		$xIPAddress += "$($IPAddress)"
+		$xIPAddress.Add("$($IPAddress)") > $Null
 	}
 
-	$xIPSubnet = @()
+	$xIPSubnet = New-Object System.Collections.ArrayList
 	ForEach($IPSubnet in $Nic.ipsubnet)
 	{
-		$xIPSubnet += "$($IPSubnet)"
+		$xIPSubnet.Add("$($IPSubnet)") > $Null
 	}
 
 	If($Null -ne $nic.dnsdomainsuffixsearchorder -and $nic.dnsdomainsuffixsearchorder.length -gt 0)
 	{
 		$nicdnsdomainsuffixsearchorder = $nic.dnsdomainsuffixsearchorder
-		$xnicdnsdomainsuffixsearchorder = @()
+		$xnicdnsdomainsuffixsearchorder = New-Object System.Collections.ArrayList
 		ForEach($DNSDomain in $nicdnsdomainsuffixsearchorder)
 		{
-			$xnicdnsdomainsuffixsearchorder += "$($DNSDomain)"
+			$xnicdnsdomainsuffixsearchorder.Add("$($DNSDomain)") > $Null
 		}
 	}
 	
 	If($Null -ne $nic.dnsserversearchorder -and $nic.dnsserversearchorder.length -gt 0)
 	{
 		$nicdnsserversearchorder = $nic.dnsserversearchorder
-		$xnicdnsserversearchorder = @()
+		$xnicdnsserversearchorder = New-Object System.Collections.ArrayList
 		ForEach($DNSServer in $nicdnsserversearchorder)
 		{
-			$xnicdnsserversearchorder += "$($DNSServer)"
+			$xnicdnsserversearchorder.Add("$($DNSServer)") > $Null
 		}
 	}
 
@@ -2367,99 +2378,99 @@ Function OutputNicItem
 
 	If($MSWORD -or $PDF)
 	{
-		[System.Collections.Hashtable[]] $NicInformation = @()
-		$NicInformation += @{ Data = "Name"; Value = $ThisNic.Name; }
+		$NicInformation = New-Object System.Collections.ArrayList
+		$NicInformation.Add(@{ Data = "Name"; Value = $ThisNic.Name; }) > $Null
 		If($ThisNic.Name -ne $nic.description)
 		{
-			$NicInformation += @{ Data = "Description"; Value = $Nic.description; }
+			$NicInformation.Add(@{ Data = "Description"; Value = $Nic.description; }) > $Null
 		}
-		$NicInformation += @{ Data = "Connection ID"; Value = $ThisNic.NetConnectionID; }
+		$NicInformation.Add(@{ Data = "Connection ID"; Value = $ThisNic.NetConnectionID; }) > $Null
 		If(validObject $Nic Manufacturer)
 		{
-			$NicInformation += @{ Data = "Manufacturer"; Value = $Nic.manufacturer; }
+			$NicInformation.Add(@{ Data = "Manufacturer"; Value = $Nic.manufacturer; }) > $Null
 		}
-		$NicInformation += @{ Data = "Availability"; Value = $xAvailability; }
-		$NicInformation += @{ Data = "Allow the computer to turn off this device to save power"; Value = $PowerSaving; }
-		$NicInformation += @{ Data = "Physical Address"; Value = $Nic.macaddress; }
+		$NicInformation.Add(@{ Data = "Availability"; Value = $xAvailability; }) > $Null
+		$NicInformation.Add(@{ Data = "Allow the computer to turn off this device to save power"; Value = $PowerSaving; }) > $Null
+		$NicInformation.Add(@{ Data = "Physical Address"; Value = $Nic.macaddress; }) > $Null
 		If($xIPAddress.Count -gt 1)
 		{
-			$NicInformation += @{ Data = "IP Address"; Value = $xIPAddress[0]; }
-			$NicInformation += @{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }
-			$NicInformation += @{ Data = "Subnet Mask"; Value = $xIPSubnet[0]; }
+			$NicInformation.Add(@{ Data = "IP Address"; Value = $xIPAddress[0]; }) > $Null
+			$NicInformation.Add(@{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }) > $Null
+			$NicInformation.Add(@{ Data = "Subnet Mask"; Value = $xIPSubnet[0]; }) > $Null
 			$cnt = -1
 			ForEach($tmp in $xIPAddress)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$NicInformation += @{ Data = "IP Address"; Value = $tmp; }
-					$NicInformation += @{ Data = "Subnet Mask"; Value = $xIPSubnet[$cnt]; }
+					$NicInformation.Add(@{ Data = "IP Address"; Value = $tmp; }) > $Null
+					$NicInformation.Add(@{ Data = "Subnet Mask"; Value = $xIPSubnet[$cnt]; }) > $Null
 				}
 			}
 		}
 		Else
 		{
-			$NicInformation += @{ Data = "IP Address"; Value = $xIPAddress; }
-			$NicInformation += @{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }
-			$NicInformation += @{ Data = "Subnet Mask"; Value = $xIPSubnet; }
+			$NicInformation.Add(@{ Data = "IP Address"; Value = $xIPAddress; }) > $Null
+			$NicInformation.Add(@{ Data = "Default Gateway"; Value = $Nic.Defaultipgateway; }) > $Null
+			$NicInformation.Add(@{ Data = "Subnet Mask"; Value = $xIPSubnet; }) > $Null
 		}
 		If($nic.dhcpenabled)
 		{
 			$DHCPLeaseObtainedDate = $nic.ConvertToDateTime($nic.dhcpleaseobtained)
 			$DHCPLeaseExpiresDate = $nic.ConvertToDateTime($nic.dhcpleaseexpires)
-			$NicInformation += @{ Data = "DHCP Enabled"; Value = $Nic.dhcpenabled; }
-			$NicInformation += @{ Data = "DHCP Lease Obtained"; Value = $dhcpleaseobtaineddate; }
-			$NicInformation += @{ Data = "DHCP Lease Expires"; Value = $dhcpleaseexpiresdate; }
-			$NicInformation += @{ Data = "DHCP Server"; Value = $Nic.dhcpserver; }
+			$NicInformation.Add(@{ Data = "DHCP Enabled"; Value = $Nic.dhcpenabled; }) > $Null
+			$NicInformation.Add(@{ Data = "DHCP Lease Obtained"; Value = $dhcpleaseobtaineddate; }) > $Null
+			$NicInformation.Add(@{ Data = "DHCP Lease Expires"; Value = $dhcpleaseexpiresdate; }) > $Null
+			$NicInformation.Add(@{ Data = "DHCP Server"; Value = $Nic.dhcpserver; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.dnsdomain))
 		{
-			$NicInformation += @{ Data = "DNS Domain"; Value = $Nic.dnsdomain; }
+			$NicInformation.Add(@{ Data = "DNS Domain"; Value = $Nic.dnsdomain; }) > $Null
 		}
 		If($Null -ne $nic.dnsdomainsuffixsearchorder -and $nic.dnsdomainsuffixsearchorder.length -gt 0)
 		{
-			$NicInformation += @{ Data = "DNS Search Suffixes"; Value = $xnicdnsdomainsuffixsearchorder[0]; }
+			$NicInformation.Add(@{ Data = "DNS Search Suffixes"; Value = $xnicdnsdomainsuffixsearchorder[0]; }) > $Null
 			$cnt = -1
 			ForEach($tmp in $xnicdnsdomainsuffixsearchorder)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$NicInformation += @{ Data = ""; Value = $tmp; }
+					$NicInformation.Add(@{ Data = ""; Value = $tmp; }) > $Null
 				}
 			}
 		}
-		$NicInformation += @{ Data = "DNS WINS Enabled"; Value = $xdnsenabledforwinsresolution; }
+		$NicInformation.Add(@{ Data = "DNS WINS Enabled"; Value = $xdnsenabledforwinsresolution; }) > $Null
 		If($Null -ne $nic.dnsserversearchorder -and $nic.dnsserversearchorder.length -gt 0)
 		{
-			$NicInformation += @{ Data = "DNS Servers"; Value = $xnicdnsserversearchorder[0]; }
+			$NicInformation.Add(@{ Data = "DNS Servers"; Value = $xnicdnsserversearchorder[0]; }) > $Null
 			$cnt = -1
 			ForEach($tmp in $xnicdnsserversearchorder)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$NicInformation += @{ Data = ""; Value = $tmp; }
+					$NicInformation.Add(@{ Data = ""; Value = $tmp; }) > $Null
 				}
 			}
 		}
-		$NicInformation += @{ Data = "NetBIOS Setting"; Value = $xTcpipNetbiosOptions; }
-		$NicInformation += @{ Data = "WINS: Enabled LMHosts"; Value = $xwinsenablelmhostslookup; }
+		$NicInformation.Add(@{ Data = "NetBIOS Setting"; Value = $xTcpipNetbiosOptions; }) > $Null
+		$NicInformation.Add(@{ Data = "WINS: Enabled LMHosts"; Value = $xwinsenablelmhostslookup; }) > $Null
 		If(![String]::IsNullOrEmpty($nic.winshostlookupfile))
 		{
-			$NicInformation += @{ Data = "Host Lookup File"; Value = $Nic.winshostlookupfile; }
+			$NicInformation.Add(@{ Data = "Host Lookup File"; Value = $Nic.winshostlookupfile; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winsprimaryserver))
 		{
-			$NicInformation += @{ Data = "Primary Server"; Value = $Nic.winsprimaryserver; }
+			$NicInformation.Add(@{ Data = "Primary Server"; Value = $Nic.winsprimaryserver; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winssecondaryserver))
 		{
-			$NicInformation += @{ Data = "Secondary Server"; Value = $Nic.winssecondaryserver; }
+			$NicInformation.Add(@{ Data = "Secondary Server"; Value = $Nic.winssecondaryserver; }) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winsscopeid))
 		{
-			$NicInformation += @{ Data = "Scope ID"; Value = $Nic.winsscopeid; }
+			$NicInformation.Add(@{ Data = "Scope ID"; Value = $Nic.winsscopeid; }) > $Null
 		}
 		$Table = AddWordTable -Hashtable $NicInformation -Columns Data,Value -List -AutoFit $wdAutoFitFixed;
 
@@ -2474,6 +2485,7 @@ Function OutputNicItem
 
 		FindWordDocumentEnd
 		$Table = $Null
+		WriteWordLine 0 0 ""
 	}
 	ElseIf($Text)
 	{
@@ -2573,107 +2585,108 @@ Function OutputNicItem
 		{
 			Line 3 "Scope ID`t`t: " $nic.winsscopeid
 		}
+		Line 0 ""
 	}
 	ElseIf($HTML)
 	{
-		$rowdata = @()
+		$rowdata = New-Object System.Collections.ArrayList
 		$columnHeaders = @("Name",($htmlsilver -bor $htmlbold),$ThisNic.Name,$htmlwhite)
 		If($ThisNic.Name -ne $nic.description)
 		{
-			$rowdata += @(,('Description',($htmlsilver -bor $htmlbold),$Nic.description,$htmlwhite))
+			$rowdata.Add(@(,('Description',($htmlsilver -bor $htmlbold),$Nic.description,$htmlwhite))) > $Null
 		}
-		$rowdata += @(,('Connection ID',($htmlsilver -bor $htmlbold),$ThisNic.NetConnectionID,$htmlwhite))
+		$rowdata.Add(@(,('Connection ID',($htmlsilver -bor $htmlbold),$ThisNic.NetConnectionID,$htmlwhite))) > $Null
 		If(validObject $Nic Manufacturer)
 		{
-			$rowdata += @(,('Manufacturer',($htmlsilver -bor $htmlbold),$Nic.manufacturer,$htmlwhite))
+			$rowdata.Add(@(,('Manufacturer',($htmlsilver -bor $htmlbold),$Nic.manufacturer,$htmlwhite))) > $Null
 		}
-		$rowdata += @(,('Availability',($htmlsilver -bor $htmlbold),$xAvailability,$htmlwhite))
-		$rowdata += @(,('Allow the computer to turn off this device to save power',($htmlsilver -bor $htmlbold),$PowerSaving,$htmlwhite))
-		$rowdata += @(,('Physical Address',($htmlsilver -bor $htmlbold),$Nic.macaddress,$htmlwhite))
-		$rowdata += @(,('IP Address',($htmlsilver -bor $htmlbold),$xIPAddress[0],$htmlwhite))
+		$rowdata.Add(@(,('Availability',($htmlsilver -bor $htmlbold),$xAvailability,$htmlwhite))) > $Null
+		$rowdata.Add(@(,('Allow the computer to turn off this device to save power',($htmlsilver -bor $htmlbold),$PowerSaving,$htmlwhite))) > $Null
+		$rowdata.Add(@(,('Physical Address',($htmlsilver -bor $htmlbold),$Nic.macaddress,$htmlwhite))) > $Null
+		$rowdata.Add(@(,('IP Address',($htmlsilver -bor $htmlbold),$xIPAddress[0],$htmlwhite))) > $Null
 		$cnt = -1
 		ForEach($tmp in $xIPAddress)
 		{
 			$cnt++
 			If($cnt -gt 0)
 			{
-				$rowdata += @(,('IP Address',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+				$rowdata.Add(@(,('IP Address',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))) > $Null
 			}
 		}
-		$rowdata += @(,('Default Gateway',($htmlsilver -bor $htmlbold),$Nic.Defaultipgateway[0],$htmlwhite))
-		$rowdata += @(,('Subnet Mask',($htmlsilver -bor $htmlbold),$xIPSubnet[0],$htmlwhite))
+		$rowdata.Add(@(,('Default Gateway',($htmlsilver -bor $htmlbold),$Nic.Defaultipgateway[0],$htmlwhite))) > $Null
+		$rowdata.Add(@(,('Subnet Mask',($htmlsilver -bor $htmlbold),$xIPSubnet[0],$htmlwhite))) > $Null
 		$cnt = -1
 		ForEach($tmp in $xIPSubnet)
 		{
 			$cnt++
 			If($cnt -gt 0)
 			{
-				$rowdata += @(,('Subnet Mask',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+				$rowdata.Add(@(,('Subnet Mask',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))) > $Null
 			}
 		}
 		If($nic.dhcpenabled)
 		{
 			$DHCPLeaseObtainedDate = $nic.ConvertToDateTime($nic.dhcpleaseobtained)
 			$DHCPLeaseExpiresDate = $nic.ConvertToDateTime($nic.dhcpleaseexpires)
-			$rowdata += @(,('DHCP Enabled',($htmlsilver -bor $htmlbold),$Nic.dhcpenabled,$htmlwhite))
-			$rowdata += @(,('DHCP Lease Obtained',($htmlsilver -bor $htmlbold),$dhcpleaseobtaineddate,$htmlwhite))
-			$rowdata += @(,('DHCP Lease Expires',($htmlsilver -bor $htmlbold),$dhcpleaseexpiresdate,$htmlwhite))
-			$rowdata += @(,('DHCP Server',($htmlsilver -bor $htmlbold),$Nic.dhcpserver,$htmlwhite))
+			$rowdata.Add(@(,('DHCP Enabled',($htmlsilver -bor $htmlbold),$Nic.dhcpenabled,$htmlwhite))) > $Null
+			$rowdata.Add(@(,('DHCP Lease Obtained',($htmlsilver -bor $htmlbold),$dhcpleaseobtaineddate,$htmlwhite))) > $Null
+			$rowdata.Add(@(,('DHCP Lease Expires',($htmlsilver -bor $htmlbold),$dhcpleaseexpiresdate,$htmlwhite))) > $Null
+			$rowdata.Add(@(,('DHCP Server',($htmlsilver -bor $htmlbold),$Nic.dhcpserver,$htmlwhite))) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.dnsdomain))
 		{
-			$rowdata += @(,('DNS Domain',($htmlsilver -bor $htmlbold),$Nic.dnsdomain,$htmlwhite))
+			$rowdata.Add(@(,('DNS Domain',($htmlsilver -bor $htmlbold),$Nic.dnsdomain,$htmlwhite))) > $Null
 		}
 		If($Null -ne $nic.dnsdomainsuffixsearchorder -and $nic.dnsdomainsuffixsearchorder.length -gt 0)
 		{
-			$rowdata += @(,('DNS Search Suffixes',($htmlsilver -bor $htmlbold),$xnicdnsdomainsuffixsearchorder[0],$htmlwhite))
+			$rowdata.Add(@(,('DNS Search Suffixes',($htmlsilver -bor $htmlbold),$xnicdnsdomainsuffixsearchorder[0],$htmlwhite))) > $Null
 			$cnt = -1
 			ForEach($tmp in $xnicdnsdomainsuffixsearchorder)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$rowdata += @(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+					$rowdata.Add(@(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))) > $Null
 				}
 			}
 		}
-		$rowdata += @(,('DNS WINS Enabled',($htmlsilver -bor $htmlbold),$xdnsenabledforwinsresolution,$htmlwhite))
+		$rowdata.Add(@(,('DNS WINS Enabled',($htmlsilver -bor $htmlbold),$xdnsenabledforwinsresolution,$htmlwhite))) > $Null
 		If($Null -ne $nic.dnsserversearchorder -and $nic.dnsserversearchorder.length -gt 0)
 		{
-			$rowdata += @(,('DNS Servers',($htmlsilver -bor $htmlbold),$xnicdnsserversearchorder[0],$htmlwhite))
+			$rowdata.Add(@(,('DNS Servers',($htmlsilver -bor $htmlbold),$xnicdnsserversearchorder[0],$htmlwhite))) > $Null
 			$cnt = -1
 			ForEach($tmp in $xnicdnsserversearchorder)
 			{
 				$cnt++
 				If($cnt -gt 0)
 				{
-					$rowdata += @(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))
+					$rowdata.Add(@(,('',($htmlsilver -bor $htmlbold),$tmp,$htmlwhite))) > $Null
 				}
 			}
 		}
-		$rowdata += @(,('NetBIOS Setting',($htmlsilver -bor $htmlbold),$xTcpipNetbiosOptions,$htmlwhite))
-		$rowdata += @(,('WINS: Enabled LMHosts',($htmlsilver -bor $htmlbold),$xwinsenablelmhostslookup,$htmlwhite))
+		$rowdata.Add(@(,('NetBIOS Setting',($htmlsilver -bor $htmlbold),$xTcpipNetbiosOptions,$htmlwhite))) > $Null
+		$rowdata.Add(@(,('WINS: Enabled LMHosts',($htmlsilver -bor $htmlbold),$xwinsenablelmhostslookup,$htmlwhite))) > $Null
 		If(![String]::IsNullOrEmpty($nic.winshostlookupfile))
 		{
-			$rowdata += @(,('Host Lookup File',($htmlsilver -bor $htmlbold),$Nic.winshostlookupfile,$htmlwhite))
+			$rowdata.Add(@(,('Host Lookup File',($htmlsilver -bor $htmlbold),$Nic.winshostlookupfile,$htmlwhite))) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winsprimaryserver))
 		{
-			$rowdata += @(,('Primary Server',($htmlsilver -bor $htmlbold),$Nic.winsprimaryserver,$htmlwhite))
+			$rowdata.Add(@(,('Primary Server',($htmlsilver -bor $htmlbold),$Nic.winsprimaryserver,$htmlwhite))) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winssecondaryserver))
 		{
-			$rowdata += @(,('Secondary Server',($htmlsilver -bor $htmlbold),$Nic.winssecondaryserver,$htmlwhite))
+			$rowdata.Add(@(,('Secondary Server',($htmlsilver -bor $htmlbold),$Nic.winssecondaryserver,$htmlwhite))) > $Null
 		}
 		If(![String]::IsNullOrEmpty($nic.winsscopeid))
 		{
-			$rowdata += @(,('Scope ID',($htmlsilver -bor $htmlbold),$Nic.winsscopeid,$htmlwhite))
+			$rowdata.Add(@(,('Scope ID',($htmlsilver -bor $htmlbold),$Nic.winsscopeid,$htmlwhite))) > $Null
 		}
 
 		$msg = ""
 		$columnWidths = @("150px","200px")
-		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths -tablewidth "350"
-		WriteHTMLLine 0 0 " "
+		FormatHTMLTable $msg -rowarray $rowdata -columnArray $columnheaders -fixedWidth $columnWidths
+		WriteHTMLLine 0 0 ""
 	}
 }
 #endregion
@@ -2682,6 +2695,7 @@ Function OutputNicItem
 Function GetComputerServices 
 {
 	Param([string]$RemoteComputerName)
+	# modified 29-Apr-2018 to change from Arrays to New-Object System.Collections.ArrayList
 	
 	#Get Computer services info
 	Write-Verbose "$(Get-Date): `t`tProcessing Computer services information"
@@ -2723,9 +2737,9 @@ Function GetComputerServices
 		{
 			WriteWordLine 0 1 "Services ($NumServices Services found)"
 
-			[System.Collections.Hashtable[]] $ServicesWordTable = @();
+			$ServicesWordTable = New-Object System.Collections.ArrayList
 			## Create an array of hashtables to store references of cells that we wish to highlight after the table has been added
-			[System.Collections.Hashtable[]] $HighlightedCells = @();
+			$HighlightedCells = New-Object System.Collections.ArrayList
 			## Seed the $Services row index from the second row
 			[int] $CurrentServiceIndex = 2;
 		}
@@ -2751,7 +2765,7 @@ Function GetComputerServices
 		ElseIf($HTML)
 		{
 			WriteHTMLLine 0 1 "Services ($NumServices Services found)"
-			$rowdata = @()
+			$rowdata = New-Object System.Collections.ArrayList
 		}
 
 		ForEach($Service in $Services) 
@@ -2769,22 +2783,17 @@ Function GetComputerServices
 				}
 
 				## Add the hash to the array
-				$ServicesWordTable += $WordTableRowHash;
+				$ServicesWordTable.Add($WordTableRowHash) > $Null
 
 				## Store "to highlight" cell references
 				If($Service.State -like "Stopped" -and $Service.StartMode -like "Auto") 
 				{
-					$HighlightedCells += @{ Row = $CurrentServiceIndex; Column = 2; }
+					$HighlightedCells.Add(@{ Row = $CurrentServiceIndex; Column = 2; }) > $Null
 				}
 				$CurrentServiceIndex++;
 			}
 			ElseIf($Text)
 			{
-				#Line 0 "Display Name`t: " $Service.DisplayName
-				#Line 0 "Status`t`t: " $Service.State
-				#Line 0 "Start Mode`t: " $Service.StartMode
-				#Line 0 ""
-				
 				#V2.16 change
 				If(($Service.DisplayName).Length -lt ($MaxDisplayNameLength))
 				{
@@ -2809,9 +2818,9 @@ Function GetComputerServices
 				{
 					$HighlightedCells = $htmlwhite
 				} 
-				$rowdata += @(,($Service.DisplayName,$htmlwhite,
+				$rowdata.Add(@(,($Service.DisplayName,$htmlwhite,
 								$Service.State,$HighlightedCells,
-								$Service.StartMode,$htmlwhite))
+								$Service.StartMode,$htmlwhite))) > $Null
 			}
 		}
 
@@ -7261,17 +7270,33 @@ Function ProcessAllDCsInTheForest
 				{
 					$GC = $Results.IsGlobalCatalog.ToString()
 					$ReadOnly = $Results.IsReadOnly.ToString()
+					#ServerOS and ServerCore added in V2.20
+					$ServerOS = $Results.OperatingSystem
+					#https://blogs.msmvps.com/russel/2017/03/16/how-to-tell-if-youre-running-on-windows-server-core/
+					$tmp = Get-RegistryValue "HKLM:\software\microsoft\windows nt\currentversion" "installationtype" $DCName
+					If($tmp -eq "Server Core")
+					{
+						$ServerCore = "Yes"
+					}
+					Else
+					{
+						$ServerCore = "No"
+					}
 				}
 				Else
 				{
 					$GC = "Unable to retrieve status"
 					$ReadOnly = "Unable to retrieve status"
+					$ServerOS = "Unable to retrieve status"
+					$ServerCore = "Unable to retrieve status"
 				}
 				
 				$WordTableRowHash += @{ 
 				DCName = $DC; 
 				GC = $GC; 
-				ReadOnly = $ReadOnly
+				ReadOnly = $ReadOnly;
+				ServerOS = $ServerOS;
+				ServerCore = $ServerCore
 				}
 				
 				$Results = $Null
@@ -7286,14 +7311,14 @@ Function ProcessAllDCsInTheForest
 			{
 				#2 is to allow for spacing between columns
 				Line 1 ("Name" + (' ' * ($MaxDCNameLength - 2))) -NoNewLine
-				Line 0 "Global Catalog            Read-only                "
+				Line 0 "Global Catalog  Read-only  Server OS                       Server Core"
 				Line 1 ('=' * $MaxDCNameLength) -NoNewLine
-				Line 0 "====================================================="
+				Line 0 "==============================================================================================="
 			}
 			Else
 			{
-				Line 1 "Name  Global Catalog            Read-only                "
-				Line 1 "==========================================================="
+				Line 1 "Name  Global Catalog  Read-only  Server OS                       Server Core"
+				Line 1 "============================================================================"
 			}
 			
 			ForEach($DC in $AllDCs)
@@ -7309,11 +7334,25 @@ Function ProcessAllDCsInTheForest
 				{
 					$xGC = $Results.IsGlobalCatalog.ToString()
 					$xRO = $Results.IsReadOnly.ToString()
+					#ServerOS and ServerCore added in V2.20
+					$ServerOS = $Results.OperatingSystem
+					#https://blogs.msmvps.com/russel/2017/03/16/how-to-tell-if-youre-running-on-windows-server-core/
+					$tmp = Get-RegistryValue "HKLM:\software\microsoft\windows nt\currentversion" "installationtype" $DCName
+					If($tmp -eq "Server Core")
+					{
+						$ServerCore = "Yes"
+					}
+					Else
+					{
+						$ServerCore = "No"
+					}
 				}
 				Else
 				{
 					$xGC = "Unable to retrieve status"
 					$xRO = "Unable to retrieve status"
+					$ServerOS = "Unable to retrieve"
+					$ServerCore = "N/A"
 				}
 
 				If(($DC).Length -lt ($MaxDCNameLength))
@@ -7324,7 +7363,7 @@ Function ProcessAllDCsInTheForest
 				{
 					[int]$NumOfSpaces = -4
 				}
-				Line 1 ( "{0,$NumOfSpaces}  {1,-25} {2,-25}" -f $DC,$xGC,$xRO)
+				Line 1 ( "{0,$NumOfSpaces}  {1,-15} {2,-10} {3,-31} {4,-3}" -f $DC,$xGC,$xRO,$ServerOS,$ServerCore)
 
 				$Results = $Null
 			}
@@ -7346,16 +7385,33 @@ Function ProcessAllDCsInTheForest
 				{
 					$GC = $Results.IsGlobalCatalog.ToString()
 					$ReadOnly = $Results.IsReadOnly.ToString()
+					#ServerOS and ServerCore added in V2.20
+					$ServerOS = $Results.OperatingSystem
+					#https://blogs.msmvps.com/russel/2017/03/16/how-to-tell-if-youre-running-on-windows-server-core/
+					$tmp = Get-RegistryValue "HKLM:\software\microsoft\windows nt\currentversion" "installationtype" $DCName
+					If($tmp -eq "Server Core")
+					{
+						$ServerCore = "Yes"
+					}
+					Else
+					{
+						$ServerCore = "No"
+					}
 				}
 				Else
 				{
 					$GC = "Unable to retrieve status"
 					$ReadOnly = "Unable to retrieve status"
+					$ServerOS = "Unable to retrieve status"
+					$ServerCore = "Unable to retrieve status"
 				}
 				
 				$rowdata += @(,($DC,$htmlwhite,
 								$GC,$htmlwhite,
-								$ReadOnly,$htmlwhite))
+								$ReadOnly,$htmlwhite,
+								$ServerOS,$htmlwhite,
+								$ServerCore,$htmlwhite
+								))
 			}
 		}
 	}
@@ -7363,17 +7419,18 @@ Function ProcessAllDCsInTheForest
 	{
 		Write-Verbose "$(Get-Date): `t`tCreate Domain Controller in Forest Word table"
 		$Table = AddWordTable -Hashtable $WordTableRowHash `
-		-Columns DCName, GC, ReadOnly `
-		-Headers "Name", "Global Catalog", "Read-only" `
+		-Columns DCName, GC, ReadOnly, ServerOS, ServerCore `
+		-Headers "Name", "Global Catalog", "Read-only", "Server OS", "Server Core" `
 		-AutoFit $wdAutoFitFixed;
 
 		SetWordCellFormat -Collection $Table.Rows.Item(1).Cells -Bold -BackgroundColor $wdColorGray15;
 
-		$Table.Columns.Item(1).Width = 200;
-		$Table.Columns.Item(2).Width = 80;
-		$Table.Columns.Item(3).Width = 65;
+		$Table.Columns.Item(1).Width = 150;
+		$Table.Columns.Item(2).Width = 50;
+		$Table.Columns.Item(3).Width = 50;
+		$Table.Columns.Item(4).Width = 130;
+		$Table.Columns.Item(5).Width = 45;
 
-		#indent the entire table 1 tab stop
 		$Table.Rows.SetLeftIndent($Indent0TabStops,$wdAdjustNone)
 
 		FindWordDocumentEnd
@@ -7388,7 +7445,9 @@ Function ProcessAllDCsInTheForest
 	{
 		$columnHeaders = @('Name',($htmlsilver -bor $htmlbold),
 							'Global Catalog',($htmlsilver -bor $htmlbold),
-							'Read-only',($htmlsilver -bor $htmlbold))
+							'Read-only',($htmlsilver -bor $htmlbold),
+							'Server OS',($htmlsilver -bor $htmlbold),
+							'Server Core',($htmlsilver -bor $htmlbold))
 		$msg = ""
 		FormatHTMLTable $msg "auto" -rowArray $rowdata -columnArray $columnHeaders
 		WriteHTMLLine 0 0 " "
@@ -8014,9 +8073,9 @@ Function ProcessADSchemaItems
 		{
 			switch ($xcol.Index)
 			{
-			  1 {$xcol.width = 200; Break}
+			  1 {$xcol.width = 175; Break}
 			  2 {$xcol.width = 75; Break}
-			  3 {$xcol.width = 200; Break}
+			  3 {$xcol.width = 175; Break}
 			}
 		}
 		
@@ -8044,7 +8103,7 @@ Function ProcessADSchemaItems
 							'Used for',($htmlsilver -bor $htmlbold)
 							)
 		$msg = ""
-		$columnWidths = @("200","75","200")
+		$columnWidths = @("175","75","175")
 		FormatHTMLTable $msg -rowArray $rowdata -columnArray $columnHeaders -fixedWidth $columnWidths -tablewidth "475"
 		WriteHTMLLine 0 0 " "
 	}
@@ -8929,8 +8988,8 @@ Function ProcessDomains
 
 	#http://technet.microsoft.com/en-us/library/bb125224(v=exchg.150).aspx
 	#http://support.microsoft.com/kb/556086/he
-	#http://blog.helocheck.com/exchange-schema-version/
 	#https://eightwone.com/references/ad-schema-versions/
+	#https://eightwone.com/references/schema-versions/
 	
 	$SchemaVersionTable = @{ 
 	"13" = "Windows 2000"; 
@@ -8961,13 +9020,13 @@ Function ProcessDomains
 	"15292" = "Exchange 2013 SP1/CU4";
 	"15300" = "Exchange 2013 CU5";
 	"15303" = "Exchange 2013 CU6";
-	"15312" = "Exchange 2013 CU7/CU8/CU9/CU10/CU11/CU12/CU13";
+	"15312" = "Exchange 2013 CU7 through CU 21"; #updated in 2.20
 	"15317" = "Exchange 2016";
 	"15323" = "Exchange 2016 CU1";
 	"15325" = "Exchange 2016 CU2";
 	"15326" = "Exchange 2016 CU3/CU4/CU5"; #added in 2.16
 	"15330" = "Exchange 2016 CU6"; #added in 2.16
-	"15332" = "Exchange 2016 CU7" #added in 2.16
+	"15332" = "Exchange 2016 CU7 through CU10" #added in 2.16 and updated in 2.20
 	}
 
 	ForEach($Domain in $Script:Domains)

--- a/ADDS_Inventory_V2.ps1
+++ b/ADDS_Inventory_V2.ps1
@@ -1114,7 +1114,12 @@ Param(
 #		If the script is run from an elevated PowerShell session by a user with Domain Admin rights
 #	Added Operating System information to Functions GetComputerWMIInfo and OutputComputerItem
 #	Code clean-up for most recommendations made by Visual Studio Code
-
+#
+#Version 2.20
+#	Added Domain Functional Level of 7 for Windows Server 2016
+#	Added Forest Functional Level of 7 for Windows Server 2016
+#	Change "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
+#	
 Set-StrictMode -Version 2
 
 #force  on
@@ -6411,7 +6416,8 @@ Function ProcessScriptSetup
 	If($ComputerName -eq "localhost")
 	{
 		$Script:ComputerName = $env:ComputerName
-		Write-Verbose "$(Get-Date): Server name has been renamed from localhost to $($ComputerName)"
+		#V2.20 change from "renamed" to "changed"
+		Write-Verbose "$(Get-Date): Server name has been changed from localhost to $($ComputerName)"
 	}
 	
 	#see if default value of $Env:USERDNSDOMAIN was used
@@ -6423,7 +6429,8 @@ Function ProcessScriptSetup
 		If($? -and $Null -ne $Results)
 		{
 			$Script:ComputerName = $Results
-			Write-Verbose "$(Get-Date): Server name has been renamed from $Env:USERDNSDOMAIN to $ComputerName"
+			#V2.20 change from "renamed" to "changed"
+			Write-Verbose "$(Get-Date): Server name has been changed from $Env:USERDNSDOMAIN to $ComputerName"
 		}
 		ElseIf(!$?) #changed for 2.16
 		{
@@ -6433,7 +6440,8 @@ Function ProcessScriptSetup
 			If($? -and $Null -ne $Results)
 			{
 				$Script:ComputerName = $Results
-				Write-Verbose "$(Get-Date): Server name has been renamed from $Env:USERDNSDOMAIN to $ComputerName"
+				#V2.20 change from "renamed" to "changed"
+				Write-Verbose "$(Get-Date): Server name has been changed from $Env:USERDNSDOMAIN to $ComputerName"
 			}
 		}
 	}
@@ -6449,7 +6457,8 @@ Function ProcessScriptSetup
 		If($? -and $Null -ne $Result)
 		{
 			$Script:ComputerName = $Result.HostName
-			Write-Verbose "$(Get-Date): Server name has been renamed from $ip to $ComputerName"
+			#V2.20 change from "renamed" to "changed"
+			Write-Verbose "$(Get-Date): Server name has been changed from $ip to $ComputerName"
 		}
 		Else
 		{
@@ -6634,6 +6643,7 @@ Function ProcessForestInformation
 		"4" {$ForestMode = "Windows Server 2008 R2"; Break}
 		"5" {$ForestMode = "Windows Server 2012"; Break}
 		"6" {$ForestMode = "Windows Server 2012 R2"; Break}
+		"7" {$ForestMode = "Windows Server 2016"; Break}	#added V2.20
 		"Windows2000Forest"        {$ForestMode = "Windows 2000"; Break}
 		"Windows2003InterimForest" {$ForestMode = "Windows Server 2003 interim"; Break}
 		"Windows2003Forest"        {$ForestMode = "Windows Server 2003"; Break}
@@ -9078,6 +9088,7 @@ Function ProcessDomains
 				"4" {$DomainMode = "Windows Server 2008 R2"; Break}
 				"5" {$DomainMode = "Windows Server 2012"; Break}
 				"6" {$DomainMode = "Windows Server 2012 R2"; Break}
+				"7" {$DomainMode = "Windows Server 2016"; Break}	#added V2.20
 				"Windows2000Domain"   		{$DomainMode = "Windows 2000"; Break}
 				"Windows2003Mixed"    		{$DomainMode = "Windows Server 2003 mixed"; Break}
 				"Windows2003Domain"   		{$DomainMode = "Windows Server 2003"; Break}

--- a/ADDS_Inventory_V2_ReadMe.rtf
+++ b/ADDS_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -35,8 +35,8 @@
 {\fbiminor\f31581\fbidi \froman\fcharset161\fprq2 Times New Roman Greek;}{\fbiminor\f31582\fbidi \froman\fcharset162\fprq2 Times New Roman Tur;}{\fbiminor\f31583\fbidi \froman\fcharset177\fprq2 Times New Roman (Hebrew);}
 {\fbiminor\f31584\fbidi \froman\fcharset178\fprq2 Times New Roman (Arabic);}{\fbiminor\f31585\fbidi \froman\fcharset186\fprq2 Times New Roman Baltic;}{\fbiminor\f31586\fbidi \froman\fcharset163\fprq2 Times New Roman (Vietnamese);}}
 {\colortbl;\red0\green0\blue0;\red0\green0\blue255;\red0\green255\blue255;\red0\green255\blue0;\red255\green0\blue255;\red255\green0\blue0;\red255\green255\blue0;\red255\green255\blue255;\red0\green0\blue128;\red0\green128\blue128;\red0\green128\blue0;
-\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\cfollowedhyperlink\ctint255\cshade255\red128\green0\blue128;\red230\green230\blue230;\red54\green95\blue145;\red79\green129\blue189;}
-{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{
+\red128\green0\blue128;\red128\green0\blue0;\red128\green128\blue0;\red128\green128\blue128;\red192\green192\blue192;\red0\green0\blue0;\red0\green0\blue0;\cfollowedhyperlink\ctint255\cshade255\red128\green0\blue128;\red230\green230\blue230;
+\red54\green95\blue145;\red79\green129\blue189;}{\*\defchp \fs22\loch\af31506\hich\af31506\dbch\af31505 }{\*\defpap \ql \li0\ri0\sa200\sl276\slmult1\widctlpar\wrapdefault\aspalpha\aspnum\faauto\adjustright\rin0\lin0\itap0 }\noqfpromote {\stylesheet{
 \ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \snext0 \sqformat \spriority0 Normal;}{
 \s1\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext0 \slink15 \sqformat 
 heading 1;}{\s2\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
@@ -47,7 +47,7 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \b\i\fs28\loch\f31502\hich\af31502\dbch\af31501 \sbasedon10 \slink2 \slocked \ssemihidden \spriority9 Heading 2 Char;}{\s17\ql \li720\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin720\itap0\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 \sbasedon0 \snext17 \sqformat \spriority34 \styrsid11488686 List Paragraph;}{\*\cs18 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf2 
 \sbasedon10 \sunhideused \styrsid11488686 Hyperlink;}{\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\f43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 
-\snext19 \sqformat \spriority1 \styrsid10945524 No Spacing;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf17 \sbasedon10 \styrsid15355254 FollowedHyperlink;}{\*\cs21 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf15\chshdng0\chcfpat0\chcbpat18 
+\snext19 \sqformat \spriority1 \styrsid10945524 No Spacing;}{\*\cs20 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \ul\cf19 \sbasedon10 \styrsid15355254 FollowedHyperlink;}{\*\cs21 \additive \rtlch\fcs1 \af0 \ltrch\fcs0 \cf15\chshdng0\chcfpat0\chcbpat20 
 \sbasedon10 \ssemihidden \sunhideused \styrsid15166704 Unresolved Mention;}}{\*\listtable{\list\listtemplateid645948268\listhybrid{\listlevel\levelnfc0\levelnfcn0\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext
 \leveltemplateid67698703\'02\'00.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li720\lin720 }{\listlevel\levelnfc4\levelnfcn4\leveljc0\leveljcn0\levelfollow0\levelstartat1\levelspace360\levelindent0{\leveltext\leveltemplateid67698713
 \'02\'01.;}{\levelnumbers\'01;}\rtlch\fcs1 \af0 \ltrch\fcs0 \fi-360\li1440\lin1440 }{\listlevel\levelnfc2\levelnfcn2\leveljc2\leveljcn2\levelfollow0\levelstartat1\lvltentative\levelspace360\levelindent0{\leveltext\leveltemplateid67698715
@@ -87,9 +87,9 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 {\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
 \levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid2638156\rsid2710199\rsid2974686\rsid3342358\rsid3477011
 \rsid3830441\rsid4281248\rsid4467197\rsid4945864\rsid5720771\rsid5767175\rsid5849890\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9838801\rsid10101060\rsid10290913
-\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid12197314\rsid12343757\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14566444
-\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
-{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2018\mo4\dy28\hr9\min29}{\version41}{\edmins538}{\nofpages23}{\nofwords7235}{\nofchars41245}{\nofcharsws48384}{\vern55}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid12197314\rsid12343757\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547
+\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
+{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2018\mo9\dy28\hr8\min49}{\version42}{\edmins538}{\nofpages23}{\nofwords7236}{\nofchars41248}{\nofcharsws48388}{\vern87}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
@@ -97,8 +97,8 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
 {\pntxtb (}{\pntxta )}}\pard\plain \ltrpar\s1\qc \li0\ri0\sb480\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel0\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf19\insrsid11602030 \hich\af43\dbch\af31505\loch\f43 Active Directory }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
-\b\fs28\cf19\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Version }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf19\insrsid13725463 \hich\af43\dbch\af31505\loch\f43 2}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf19\insrsid11488686 
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11602030 \hich\af43\dbch\af31505\loch\f43 Active Directory }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 
+\b\fs28\cf21\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Version }{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid13725463 \hich\af43\dbch\af31505\loch\f43 2}{\rtlch\fcs1 \ab\af43\afs28 \ltrch\fcs0 \b\fs28\cf21\insrsid11488686 
 \hich\af43\dbch\af31505\loch\f43  Documentation Script ReadMe
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \ab\af37\afs28 \ltrch\fcs0 \b\f37\fs28\insrsid11488686 
@@ -106,7 +106,7 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 NOTE: This script requires PowerShell V3 or later.
 \par \hich\af31506\dbch\af31505\loch\f31506 NOTE: Word 2007 is no longer supported.}{\rtlch\fcs1 \af37 \ltrch\fcs0 \f31506\insrsid5767175\charrsid667579 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf20\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Support for non-English Versions of Microsoft Word
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 T}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 he script supports the following languages:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f3\fs22\insrsid11488686\charrsid13987238 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
@@ -128,7 +128,7 @@ NOTE: This script requires PowerShell V3 or later.
 \f37\fs22\insrsid11488686 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid10290913 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf20\insrsid10290913 \page \hich\af43\dbch\af31505\loch\f43 What the Script Documents
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid10290913 \page \hich\af43\dbch\af31505\loch\f43 What the Script Documents
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0\afs22 
 \ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 The following items are documented:
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid10290913\charrsid10290913 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls4\rin0\lin720\itap0\pararsid10290913 {
@@ -138,7 +138,7 @@ NOTE: This script requires PowerShell V3 or later.
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f2\fs22\insrsid8013811 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls4\ilvl1\rin0\lin1440\itap0\pararsid8013811 {\rtlch\fcs1 
 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid8013811 \hich\af37\dbch\af31505\loch\f37 Certificate Authorities
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f2\fs22\insrsid1520287 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls4\ilvl1\rin0\lin1440\itap0\pararsid1520287 {\rtlch\fcs1 
-\af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid1520287 \hich\af31506\dbch\af31505\loch\f31506 AD Optional Fe\hich\af31506\dbch\af31505\loch\f31506 atures
+\af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid1520287 \hich\af31506\dbch\af31505\loch\f31506 AD Optional Features
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f2\fs22\insrsid12197314 \hich\af2\dbch\af31505\loch\f2 o\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid12197314 \hich\af31506\dbch\af31505\loch\f31506 Schema Extension Items}{
 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid12197314\charrsid10290913 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid10290913\charrsid10290913 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls4\rin0\lin720\itap0\pararsid10290913 {
@@ -248,13 +248,13 @@ All users with RDS Homedrive set in ADUC}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3
 \ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls4\ilvl1\rin0\lin1440\itap0\pararsid10290913 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 Computer Operating Systems
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid1520287 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls4\rin0\lin720\itap0\pararsid1520287 {\rtlch\fcs1 
 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid1520287 \hich\af31506\dbch\af31505\loch\f31506 Domain Controller DNS IP Configuration}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10290913 
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid854968 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid854968 \hich\af31506\dbch\af31505\loch\f31506 
-Domain Controller Time Server Inform\hich\af31506\dbch\af31505\loch\f31506 ation
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid854968 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid854968 \hich\af31506\dbch\af31505\loch\f31506 Doma
+\hich\af31506\dbch\af31505\loch\f31506 in Controller Time Server Information
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid12792789 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid12792789 \hich\af31506\dbch\af31505\loch\f31506 
 Domain Controller Event Log Information}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid12792789\charrsid10290913 
 \par }\pard \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913 {\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10290913 
 \par }{\rtlch\fcs1 \af0 \ltrch\fcs0 \insrsid10290913\charrsid10290913 
-\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11602030 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf20\insrsid11488686 
+\par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11602030 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \page }{\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11488686 
 \hich\af43\dbch\af31505\loch\f43 Prerequisites
 \par }\pard \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 
 Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 Active Directory}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 
@@ -262,7 +262,7 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 At least one Windows Server 2008 R2 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 or later }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 do\hich\af37\dbch\af31505\loch\f37 main controller.
+\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 domain controller.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 
 At least one Windows 7 SP1 or later computer with the Remote Server Administration Tools (RSAT) installed.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -270,19 +270,19 @@ At least one Windows 7 SP1 or later computer with the Remote Server Administrati
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 
  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=7887" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9200000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff0000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff000060}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d014}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Too\hich\af37\dbch\af31505\loch\f37 ls for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d0146d}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration To\hich\af37\dbch\af31505\loch\f37 ols for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a6400}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a64006d}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -290,17 +290,17 @@ At least one Windows 7 SP1 or later computer with the Remote Server Administrati
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff0000000000000900730000000000000000000000000000006300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \par \hich\af37\dbch\af31505\loch\f37 This script was developed using Windows Server 20}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 12}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \hich\af37\dbch\af31505\loch\f37  R2 domain controllers and PowerShell Version }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 5}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-\hich\af37\dbch\af31505\loch\f37 .0. The scr\hich\af37\dbch\af31505\loch\f37 ipt was run on several Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 10}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  computers with RSAT}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37  and }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-\hich\af37\dbch\af31505\loch\f37 Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid5849890 \hich\af37\dbch\af31505\loch\f37  The script now requires PowerShell V3 or later.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
+\hich\af37\dbch\af31505\loch\f37 .0. The script was run on several Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 10}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
+\hich\af37\dbch\af31505\loch\f37  computers with RSAT}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37  and }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 
+Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5849890 
+\hich\af37\dbch\af31505\loch\f37  The script now requires PowerShell V3 or later.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf20\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Script Usage
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Script Usage
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 How to use this script?
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
@@ -309,8 +309,8 @@ At least one Windows 7 SP1 or later computer with the Remote Server Administrati
 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventor}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 y}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2638156 
 \hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 in your PowerShell scripts folder.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell \hich\af37\dbch\af31505\loch\f37 
-prompt, change to your PowerShell scripts}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13133162 \hich\af37\dbch\af31505\loch\f37  folder}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, change to your PowerShell scripts}{
+\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13133162 \hich\af37\dbch\af31505\loch\f37  folder}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 3.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, type in:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11602030 .\\}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2638156 
@@ -348,17 +348,17 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par }\pard\plain \ltrpar\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 Full help text is available.
 \par 
-\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2638156 \hich\af37\dbch\af31505\loch\f37 ADDS_Inventory_V2}{\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
+\par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2638156 \hich\af37\dbch\af31505\loch\f37 ADDS_\hich\af37\dbch\af31505\loch\f37 Inventory_V2
+}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
 \par 
 \par \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid10945524 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
-\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf20\insrsid10945524 \hich\af43\dbch\af31505\loch\f43 Help Text
+\fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid10945524 \hich\af43\dbch\af31505\loch\f43 Help Text
 \par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10945524 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid10945524 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10902102 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2 PSScript\hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \\
-\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V2.ps1
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \\\hich\af2\dbch\af31505\loch\f2 
+ADDS_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest.
@@ -371,49 +371,48 @@ ADDS_Inventory_V2.ps1 [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \a
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-UserName <String>] [-MSWord] [-AddDateTime] [-ADForest }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <String>] [-ADDomain <String>] [-ComputerName <String>] [-DCDNSInfo] [-Folder }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <S\hich\af2\dbch\af31505\loch\f2 tring>] [-GPOInheritance]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-IncludeUserInfo] [-MaxDetails] [-Services] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <Strin\hich\af2\dbch\af31505\loch\f2 g>] [-ADDomain <String>] [-ComputerName <String>] [-DCDNSInfo] [-Folder }
+{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <String>] [-GPOInheritance]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-IncludeUserInfo] [-MaxDetails] [-Services] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-Section <Array>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \\\hich\af2\dbch\af31505\loch\f2 
 ADDS_Inventory_V2.ps1 [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-UserName <String>] [-HTML] [-MSWord] [-PDF] [-Text] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <S\hich\af2\dbch\af31505\loch\f2 tring>] [-UserName <String>] [-HTML] [-MSWord] [-PDF] [-Text] }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-AddDateTime] [-ADForest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [\hich\af2\dbch\af31505\loch\f2 -DCDNSInfo] [-Folder <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-GPOInheritance] [-Hardware] [-IncludeUserInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-MaxDetails] [-Services] [-Section <Array>] -SmtpServer <String> [-SmtpPort <Int32>] }{\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-UseSSL] -From <String> -To <String> [-Dev] [-ScriptInfo] [-Log] [<CommonParame
-\hich\af2\dbch\af31505\loch\f2 ters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-DCDNSInfo] [-Folder <String>]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
+\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-GPOInheritance] [-Hardware] [-IncludeUserInfo] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
+
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-MaxDetails] [-\hich\af2\dbch\af31505\loch\f2 
+Services] [-Section <Array>] -SmtpServer <String> [-SmtpPort <Int32>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-UseSSL] -From <String> -To <String> [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \\\hich\af2\dbch\af31505\loch\f2 
 ADDS_Inventory_V2.ps1 [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <String>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-UserName <String>] [-PDF] [-AddDateTime] [-ADForest\hich\af2\dbch\af31505\loch\f2 
- <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <String\hich\af2\dbch\af31505\loch\f2 
+>] [-CompanyFax <String>] [-CompanyName <String>] [-CompanyPhone <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-CoverPage <String>] [-UserName <String>] [-PDF] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-ADDomain <String>] [-ComputerName <String>] [-DCDNSInfo] [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-GPOInheritance] [-Hardware]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-IncludeUserInfo] [-MaxDetails] [-Services] [-Section }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-\hich\af2\dbch\af31505\loch\f2 GPOInheritance] [-Hardware]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-IncludeUserInfo] [-MaxDetails] [-Services] [-Section }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <Array>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2 P\hich\af2\dbch\af31505\loch\f2 SScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \\
-\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V2.ps1 [-HTML] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-ADDomain <String>] [-ComputerName <String>] [-DCDNSInfo] [-Folder <String>] }{\rtlch\fcs1 \af2\afs18 
-\ltrch\fcs0 \f2\fs18\insrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \\\hich\af2\dbch\af31505\loch\f2 
+ADDS_Inventory_V2.ps1 [-HTML] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-ADDomain <String>] \hich\af2\dbch\af31505\loch\f2 [-ComputerName <String>] [-DCDNSInfo] [-Folder <String>] }
+{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-GPOInheritance] [-Hardware] [-IncludeUserInfo] [-MaxDetails] [-Services] [-Section }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <Ar\hich\af2\dbch\af31505\loch\f2 ray>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <Array>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \\\hich\af2\dbch\af31505\loch\f2 
 ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
@@ -421,22 +420,22 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-GPOInheritance] [-Hardware] [-IncludeUserInfo] [-MaxDetails] [-Services] [-Section }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <Array>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <Array>] [-D\hich\af2\dbch\af31505\loch\f2 ev] [-ScriptInfo] [-Log] [<CommonParameters>]
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest using Microsoft
-\par \hich\af2\dbch\af31505\loch\f2     Po\hich\af2\dbch\af31505\loch\f2 werShell, Word, plain text or HTML.
+\par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text or HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text or HTML file named after the Active Directory Forest.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text or HTML file named after\hich\af2\dbch\af31505\loch\f2  the Active Directory Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents and Footer.
-\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following langu\hich\af2\dbch\af31505\loch\f2 age versions of Microsoft Word:
+\par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
 \par \hich\af2\dbch\af31505\loch\f2         Catalan
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
-\par \hich\af2\dbch\af31505\loch\f2         English
+\par \hich\af2\dbch\af31505\loch\f2         E\hich\af2\dbch\af31505\loch\f2 nglish
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
@@ -445,37 +444,37 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Spanish
 \par \hich\af2\dbch\af31505\loch\f2         Swedish
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script requires at leas\hich\af2\dbch\af31505\loch\f2 t PowerShell version 3 but runs best in version 5.
+\par \hich\af2\dbch\af31505\loch\f2     The script requires at least PowerShell version 3 but runs best in version 5.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word is NOT needed to run the script. This script will output in Text and HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a domain controller. This script was developed
 \par \hich\af2\dbch\af31505\loch\f2     and run from a Windows 10 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     While most of the script can be run with a non-admin account, there are some features
+\par \hich\af2\dbch\af31505\loch\f2     While most of the script can be run with a \hich\af2\dbch\af31505\loch\f2 non-admin account, there are some features
 \par \hich\af2\dbch\af31505\loch\f2     that will not or may not work without domain admin or enterprise admin rights.
-\par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters require\hich\af2\dbch\af31505\loch\f2  domain admin privileges.
+\par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters require domain admin privileges.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Version 2.0 of the script adds gathering information on Time Server and AD database,
+\par \hich\af2\dbch\af31505\loch\f2     Version 2.0 of the script adds gathering informatio\hich\af2\dbch\af31505\loch\f2 n on Time Server and AD database,
 \par \hich\af2\dbch\af31505\loch\f2     log file, and SYSVOL locations. Those require access to the registry on each domain
-\par \hich\af2\dbch\af31505\loch\f2     controller, which means the script should now al\hich\af2\dbch\af31505\loch\f2 ways be run from an elevated PowerShell
-\par \hich\af2\dbch\af31505\loch\f2     session with an account with a minimum of domain admin rights.
+\par \hich\af2\dbch\af31505\loch\f2     controller, which means the script should now always be run from an elevated PowerShell
+\par \hich\af2\dbch\af31505\loch\f2     session with an account with a minimum\hich\af2\dbch\af31505\loch\f2  of domain admin rights.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Running the script in a forest with multiple domains requires Enterprise Admin rights.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if the us\hich\af2\dbch\af31505\loch\f2 er running the script doesn't have
-\par \hich\af2\dbch\af31505\loch\f2     the necessary permissions on all user objects.  In that case, there may be user accounts
+\par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if the user running the script doesn't have
+\par \hich\af2\dbch\af31505\loch\f2     the necessary permissions on all user objec\hich\af2\dbch\af31505\loch\f2 ts.  In that case, there may be user accounts
 \par \hich\af2\dbch\af31505\loch\f2     classified as "unknown".
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To run the script from a workstation, RSAT is required.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tool\hich\af2\dbch\af31505\loch\f2 s for Windows 7 with Service Pack 1 (SP1)
-\par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=7887
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)
+\par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/d\hich\af2\dbch\af31505\loch\f2 ownload/details.aspx?id=7887
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=28972
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Ad\hich\af2\dbch\af31505\loch\f2 ministration Tools for Windows 8.1
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=39296
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
@@ -483,27 +482,27 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyA\hich\af2\dbch\af31505\loch\f2 ddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Add\hich\af2\dbch\af31505\loch\f2 ress to use for the Cover Page, if the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2              \hich\af2\dbch\af31505\loch\f2    Exposure (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaste\hich\af2\dbch\af31505\loch\f2 r (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This pa\hich\af2\dbch\af31505\loch\f2 rameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
@@ -515,24 +514,24 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    \hich\af2\dbch\af31505\loch\f2 false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Default value
+\par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the \hich\af2\dbch\af31505\loch\f2 Fax field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fa\hich\af2\dbch\af31505\loch\f2 x field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias o\hich\af2\dbch\af31505\loch\f2 f CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -542,11 +541,11 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
-\par \hich\af2\dbch\af31505\loch\f2         This pa\hich\af2\dbch\af31505\loch\f2 rameter has an alias of CN.
+\par \hich\af2\dbch\af31505\loch\f2         on \hich\af2\dbch\af31505\loch\f2 the computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
 \par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the report
 \par \hich\af2\dbch\af31505\loch\f2         will not contain a Company Name on the cover page.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output paramet\hich\af2\dbch\af31505\loch\f2 ers.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is o\hich\af2\dbch\af31505\loch\f2 nly valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -554,14 +553,14 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use\hich\af2\dbch\af31505\loch\f2  for the Cover Page if the Cover Page has the Phone field.
+\par \hich\af2\dbch\af31505\loch\f2     -Co\hich\af2\dbch\af31505\loch\f2 mpanyPhone <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output\hich\af2\dbch\af31505\loch\f2  parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parame\hich\af2\dbch\af31505\loch\f2 ter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -577,45 +576,45 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Ann\hich\af2\dbch\af31505\loch\f2 ual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
-\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be mo\hich\af2\dbch\af31505\loch\f2 ved
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, \hich\af2\dbch\af31505\loch\f2 mostly
+\par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
 \par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast \hich\af2\dbch\af31505\loch\f2 (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure\hich\af2\dbch\af31505\loch\f2  (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resiz\hich\af2\dbch\af31505\loch\f2 ed or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010.\hich\af2\dbch\af31505\loch\f2  Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Wor\hich\af2\dbch\af31505\loch\f2 d 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Sl\hich\af2\dbch\af31505\loch\f2 ice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Work\hich\af2\dbch\af31505\loch\f2 s)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Wor\hich\af2\dbch\af31505\loch\f2 ks)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is Si\hich\af2\dbch\af31505\loch\f2 deline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
@@ -627,19 +626,19 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    \hich\af2\dbch\af31505\loch\f2 named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    na\hich\af2\dbch\af31505\loch\f2 med
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is di\hich\af2\dbch\af31505\loch\f2 sabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disa\hich\af2\dbch\af31505\loch\f2 bled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -647,34 +646,34 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<Switch\hich\af2\dbch\af31505\loch\f2 Parameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchPa\hich\af2\dbch\af31505\loch\f2 rameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger \hich\af2\dbch\af31505\loch\f2 than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value    \hich\af2\dbch\af31505\loch\f2             False
+\par \hich\af2\dbch\af31505\loch\f2         Position?      \hich\af2\dbch\af31505\loch\f2               named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This pa\hich\af2\dbch\af31505\loch\f2 rameter is disabled by default.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Requ\hich\af2\dbch\af31505\loch\f2 ired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -684,26 +683,26 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2         June 1, 2018 at 6PM is 2018-06-01_1800.
-\par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2018-06-01_1800.docx (or .pdf).
-\par \hich\af2\dbch\af31505\loch\f2         This p\hich\af2\dbch\af31505\loch\f2 arameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Output filename will be ReportName_2018-06-01_1800.docx (or .pdf).
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Acce\hich\af2\dbch\af31505\loch\f2 pt pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -A\hich\af2\dbch\af31505\loch\f2 DForest <String>
+\par \hich\af2\dbch\af31505\loch\f2     -ADForest <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory forest object by providing one of the following
 \par \hich\af2\dbch\af31505\loch\f2         attribute values.
-\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the attribute.
+\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the L\hich\af2\dbch\af31505\loch\f2 DAP display name for the attribute.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Fully qualified domain name
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         Example: labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par \hich\af2\dbch\af31505\loch\f2                 Example: 599c3d2e-e61e-4d20-7b77-030d99495e19
 \par \hich\af2\dbch\af31505\loch\f2         DNS host name
-\par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2                 Example: labaddo\hich\af2\dbch\af31505\loch\f2 main.com
 \par \hich\af2\dbch\af31505\loch\f2         NetBIOS name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain
 \par 
@@ -713,14 +712,14 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:US\hich\af2\dbch\af31505\loch\f2 ERDNSDOMAIN
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?   \hich\af2\dbch\af31505\loch\f2     false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in paren\hich\af2\dbch\af31505\loch\f2 theses is the LDAP display name for the
-\par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the domain.
+\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in parentheses is the LDAP display name for the
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    attribute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
 \par 
@@ -728,9 +727,9 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Exam\hich\af2\dbch\af31505\loch\f2 ple: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
+\par \hich\af2\dbch\af31505\loch\f2         Example: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Security Identifier (objectSid)
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Security Identifier (objectSid)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Example: S-1-5-21-3643273344-1505409314-3732760578
 \par 
@@ -747,50 +746,50 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies which domain controller to use to run the script against.
 \par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName is required to detect the
-\par \hich\af2\dbch\af31505\loch\f2         existence of\hich\af2\dbch\af31505\loch\f2  ADForest.
-\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         existence of ADForest.
+\par \hich\af2\dbch\af31505\loch\f2         ComputerN\hich\af2\dbch\af31505\loch\f2 ame can be entered as the NetBIOS name, FQDN, localhost or IP Address.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and us\hich\af2\dbch\af31505\loch\f2 e the actual
-\par \hich\af2\dbch\af31505\loch\f2         computer name.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
+\par \hich\af2\dbch\af31505\loch\f2         compute\hich\af2\dbch\af31505\loch\f2 r name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ServerName.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                \hich\af2\dbch\af31505\loch\f2 $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DCDNSInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather, for each domain controller, the IP Address, and each DNS server
 \par \hich\af2\dbch\af31505\loch\f2         configured.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         This parameter \hich\af2\dbch\af31505\loch\f2 requires the script be run from an elevated PowerShell session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add an extra section to the r\hich\af2\dbch\af31505\loch\f2 eport.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add an extra section to the report.
+\par \hich\af2\dbch\af31505\loch\f2         This par\hich\af2\dbch\af31505\loch\f2 ameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard chara\hich\af2\dbch\af31505\loch\f2 cters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
+\par \hich\af2\dbch\af31505\loch\f2     -Fol\hich\af2\dbch\af31505\loch\f2 der <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wild\hich\af2\dbch\af31505\loch\f2 card characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -GPOInheritance [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         In the Group Policies by OU section, adds Inherited GPOs in addition to the GPOs
@@ -801,25 +800,25 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of GPO.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    na\hich\af2\dbch\af31505\loch\f2 med
+\par \hich\af2\dbch\af31505\loch\f2         Required?             \hich\af2\dbch\af31505\loch\f2        false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware i\hich\af2\dbch\af31505\loch\f2 nformation on Computer System, Disks, Processor, and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domai\hich\af2\dbch\af31505\loch\f2 n
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter w\hich\af2\dbch\af31505\loch\f2 ill add to both the time it takes to run the script and
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                F\hich\af2\dbch\af31505\loch\f2 alse
+\par \hich\af2\dbch\af31505\loch\f2         Position?            \hich\af2\dbch\af31505\loch\f2         named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -830,26 +829,26 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2                 Disabled users
 \par \hich\af2\dbch\af31505\loch\f2                 Unknown users
 \par \hich\af2\dbch\af31505\loch\f2                 Locked out users
-\par \hich\af2\dbch\af31505\loch\f2                 All users with password expired
-\par \hich\af2\dbch\af31505\loch\f2                 All users whose password neve\hich\af2\dbch\af31505\loch\f2 r expires
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            All users with password expired
+\par \hich\af2\dbch\af31505\loch\f2                 All users whose password never expires
 \par \hich\af2\dbch\af31505\loch\f2                 All users with password not required
 \par \hich\af2\dbch\af31505\loch\f2                 All users who cannot change password
 \par \hich\af2\dbch\af31505\loch\f2                 All users with SID History
-\par \hich\af2\dbch\af31505\loch\f2                 All users with Homedrive set in ADUC
-\par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Grou\hich\af2\dbch\af31505\loch\f2 p is not Domain Users
+\par \hich\af2\dbch\af31505\loch\f2          \hich\af2\dbch\af31505\loch\f2        All users with Homedrive set in ADUC
+\par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Group is not Domain Users
 \par \hich\af2\dbch\af31505\loch\f2                 All users with RDS HomeDrive set in ADUC
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited to the first 25 characters of the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited to the first 25 characters of the SamAccountNa\hich\af2\dbch\af31505\loch\f2 me
 \par \hich\af2\dbch\af31505\loch\f2         and the first 116 characters of the DistinguishedName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of IU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Defa\hich\af2\dbch\af31505\loch\f2 ult value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept\hich\af2\dbch\af31505\loch\f2  wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
@@ -861,25 +860,25 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2                 IncludeUserInfo
 \par \hich\af2\dbch\af31505\loch\f2                 Services
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
+\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extr\hich\af2\dbch\af31505\loch\f2 emely large report and
 \par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?              \hich\af2\dbch\af31505\loch\f2       false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept p\hich\af2\dbch\af31505\loch\f2 ipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Services [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gather information on all ser\hich\af2\dbch\af31505\loch\f2 vices running on domain controllers.
-\par \hich\af2\dbch\af31505\loch\f2         Servers that are configured to automatically start but are not running will be
+\par \hich\af2\dbch\af31505\loch\f2         Gather information on all services running on domain controllers.
+\par \hich\af2\dbch\af31505\loch\f2         Servers that are configured to automatically start but are not runnin\hich\af2\dbch\af31505\loch\f2 g will be
 \par \hich\af2\dbch\af31505\loch\f2         colored in red.
 \par \hich\af2\dbch\af31505\loch\f2         Used on Domain Controllers only.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated \hich\af2\dbch\af31505\loch\f2 PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve service information (i.e. Domain
-\par \hich\af2\dbch\af31505\loch\f2         Admin).
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 dmin).
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
@@ -888,16 +887,16 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <Array>
-\par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Processes o\hich\af2\dbch\af31505\loch\f2 ne or more sections of the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Forest
 \par \hich\af2\dbch\af31505\loch\f2                 Sites
 \par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers and optional Hardware, Services and
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     DCDNSInfo)
-\par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
+\par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
+\par \hich\af2\dbch\af31505\loch\f2                 OUs (Organization\hich\af2\dbch\af31505\loch\f2 al Units)
 \par \hich\af2\dbch\af31505\loch\f2                 Groups
 \par \hich\af2\dbch\af31505\loch\f2                 GPOs
 \par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
@@ -905,9 +904,9 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated b\hich\af2\dbch\af31505\loch\f2 y a comma. -Section forest, domains
+\par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated by a comma. -Section forest, domains
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Req\hich\af2\dbch\af31505\loch\f2 uired?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -920,7 +919,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters\hich\af2\dbch\af31505\loch\f2 ?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
@@ -929,7 +928,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
-\par \hich\af2\dbch\af31505\loch\f2         Acce\hich\af2\dbch\af31505\loch\f2 pt pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       \hich\af2\dbch\af31505\loch\f2 false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
@@ -937,7 +936,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position? \hich\af2\dbch\af31505\loch\f2                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -949,7 +948,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inpu\hich\af2\dbch\af31505\loch\f2 t?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
@@ -957,43 +956,43 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accep\hich\af2\dbch\af31505\loch\f2 t pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text fil\hich\af2\dbch\af31505\loch\f2 e at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the \hich\af2\dbch\af31505\loch\f2 script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Pos\hich\af2\dbch\af31505\loch\f2 ition?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text fil\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter\hich\af2\dbch\af31505\loch\f2  has an alias of SI.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    \hich\af2\dbch\af31505\loch\f2 named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchP\hich\af2\dbch\af31505\loch\f2 arameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    fal\hich\af2\dbch\af31505\loch\f2 se
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -1002,15 +1001,15 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2     <CommonParameters>
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
-\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/g\hich\af2\dbch\af31505\loch\f2 o.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable.\hich\af2\dbch\af31505\loch\f2  For more information, see
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
 \par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
-\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word or PDF document.
+\par \hich\af2\dbch\af31505\loch\f2     No objects are output from this script.  This script creates a Word or PDF d\hich\af2\dbch\af31505\loch\f2 ocument.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
@@ -1021,17 +1020,18 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \f2\fs18\insrsid10902102\charrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster, Sr. Solutions Architect, Choice Solutions, LLC and Michael }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13791374 \hich\af2\dbch\af31505\loch\f2 April }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5720771 \hich\af2\dbch\af31505\loch\f2 28}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12792789 \hich\af2\dbch\af31505\loch\f2 , 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid14176547 \hich\af2\dbch\af31505\loch\f2 September}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13791374 \hich\af2\dbch\af31505\loch\f2  }{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5720771 \hich\af2\dbch\af31505\loch\f2 28}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12792789 \hich\af2\dbch\af31505\loch\f2 , 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid10902102\charrsid10902102 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE\hich\af2\dbch\af31505\loch\f2  1 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_\hich\af2\dbch\af31505\loch\f2 V2.ps1
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1040,7 +1040,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $En\hich\af2\dbch\af31505\loch\f2 v:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1049,12 +1049,12 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 2 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\AD\hich\af2\dbch\af31505\loch\f2 DS_Inventory_V2.ps1 -ADForest company.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webs\hich\af2\dbch\af31505\loch\f2 ter"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Micro\hich\af2\dbch\af31505\loch\f2 soft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1069,22 +1069,22 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 3 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     --------\hich\af2\dbch\af31505\loch\f2 ------------------ EXAMPLE 3 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADDomain child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     Webster\hich\af2\dbch\af31505\loch\f2 " or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     child.company.tld for the AD Domain.
+\par \hich\af2\dbch\af31505\loch\f2     child.com\hich\af2\dbch\af31505\loch\f2 pany.tld for the AD Domain.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Com\hich\af2\dbch\af31505\loch\f2 puterName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1097,20 +1097,20 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT\hich\af2\dbch\af31505\loch\f2 _USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     A\hich\af2\dbch\af31505\loch\f2 dministrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline \hich\af2\dbch\af31505\loch\f2 for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Because both ADForest and ADDomain are specified, ADDomain wins and child.company.tld
 \par \hich\af2\dbch\af31505\loch\f2     is used for AD Domain.
 \par \hich\af2\dbch\af31505\loch\f2     ADForest is set to the value of ADDomain.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAI\hich\af2\dbch\af31505\loch\f2 N, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults t\hich\af2\dbch\af31505\loch\f2 o the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1119,31 +1119,31 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 5 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V2.ps1 -ADForest company.tld -ComputerName DC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest company.tld -ComputerName DC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Comp\hich\af2\dbch\af31505\loch\f2 anyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserIn\hich\af2\dbch\af31505\loch\f2 fo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the\hich\af2\dbch\af31505\loch\f2  User Name.
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest
-\par \hich\af2\dbch\af31505\loch\f2     The script will be run remotely on the DC\hich\af2\dbch\af31505\loch\f2 01 domain controller.
+\par \hich\af2\dbch\af31505\loch\f2     The script will be run remotely on the DC01 domain controller.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -PDF -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -PDF -ADForest corp.carlwe\hich\af2\dbch\af31505\loch\f2 bster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CU\hich\af2\dbch\af31505\loch\f2 RRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl \hich\af2\dbch\af31505\loch\f2 Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1152,7 +1152,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a globa\hich\af2\dbch\af31505\loch\f2 l catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
@@ -1162,18 +1162,18 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -Text -ADForest corp.carlwebster.com
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values\hich\af2\dbch\af31505\loch\f2  and save the document as a formatted text file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyNa\hich\af2\dbch\af31505\loch\f2 me="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Ad\hich\af2\dbch\af31505\loch\f2 ministrator.
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the Use\hich\af2\dbch\af31505\loch\f2 r Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script que\hich\af2\dbch\af31505\loch\f2 ries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1182,12 +1182,12 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -HTML -ADForest \hich\af2\dbch\af31505\loch\f2 corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -HTML -ADForest corp.carl\hich\af2\dbch\af31505\loch\f2 webster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompany="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="C\hich\af2\dbch\af31505\loch\f2 arl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1195,7 +1195,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the valu\hich\af2\dbch\af31505\loch\f2 e of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env\hich\af2\dbch\af31505\loch\f2 :USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1204,47 +1204,47 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\ADDS_Inventory_V2.ps1 -hardware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for each domain controller
 \par \hich\af2\dbch\af31505\loch\f2     about its hardware.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_U\hich\af2\dbch\af31505\loch\f2 SER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline f\hich\af2\dbch\af31505\loch\f2 or the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a glob\hich\af2\dbch\af31505\loch\f2 al catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -services
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional infor\hich\af2\dbch\af31505\loch\f2 mation for the services running
+\par \hich\af2\dbch\af31505\loch\f2     on each domain controller.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest de\hich\af2\dbch\af31505\loch\f2 faults to the value of $Env:USERDNSDOMAIN.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -------------------------- EXAMPLE 10 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -services
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for the services running
-\par \hich\af2\dbch\af31505\loch\f2     on each domain controller.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Na\hich\af2\dbch\af31505\loch\f2 me.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller t\hich\af2\dbch\af31505\loch\f2 hat is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defa\hich\af2\dbch\af31505\loch\f2 ults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
@@ -1254,11 +1254,11 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -DCDNSInfo
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and a\hich\af2\dbch\af31505\loch\f2 dd additional information for each domain controller
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for each domain controller
 \par \hich\af2\dbch\af31505\loch\f2     about its DNS IP configuration.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyNa\hich\af2\dbch\af31505\loch\f2 me="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compa\hich\af2\dbch\af31505\loch\f2 ny="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1268,22 +1268,22 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMA\hich\af2\dbch\af31505\loch\f2 IN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for Compute\hich\af2\dbch\af31505\loch\f2 rName.
+\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inv\hich\af2\dbch\af31505\loch\f2 entory_V2.ps1 -CompanyName "Carl Webster Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Carl Webster Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the\hich\af2\dbch\af31505\loch\f2  User Name.
 \par \hich\af2\dbch\af31505\loch\f2         ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par \hich\af2\dbch\af31505\loch\f2         Domain Controller named ADDC01 for the ComputerName.
 \par 
@@ -1359,22 +1359,22 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest company.tld -AddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest company.tld -A\hich\af2\dbch\af31505\loch\f2 ddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\\hich\af2\dbch\af31505\loch\f2 Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Admini\hich\af2\dbch\af31505\loch\f2 strator.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page forma\hich\af2\dbch\af31505\loch\f2 t.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
@@ -1386,25 +1386,25 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -PDF -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V2.ps1 -PDF -ADForest corp.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_US\hich\af2\dbch\af31505\loch\f2 ER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for\hich\af2\dbch\af31505\loch\f2  the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for t\hich\af2\dbch\af31505\loch\f2 he AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server\hich\af2\dbch\af31505\loch\f2  and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the en\hich\af2\dbch\af31505\loch\f2 d of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, 2018 at 6PM is 2018-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2     Output filename will be corp.carlwebster.com_2018-06-01_1800.PDF
@@ -1417,19 +1417,19 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest corp.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -Folder \\\\FileServer\\ShareName
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\O\hich\af2\dbch\af31505\loch\f2 ffice\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     C\hich\af2\dbch\af31505\loch\f2 arl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a doma\hich\af2\dbch\af31505\loch\f2 in controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as t\hich\af2\dbch\af31505\loch\f2 he
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The output file will be saved in the path \\\\FileServer\\ShareName.
@@ -1439,27 +1439,27 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V2.ps1 -ADForest corp.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mail.domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName Server01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\M\hich\af2\dbch\af31505\loch\f2 icrosoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Pa\hich\af2\dbch\af31505\loch\f2 ge format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Adminis\hich\af2\dbch\af31505\loch\f2 trator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will be run remotely against server Server01.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
-\par \hich\af2\dbch\af31505\loch\f2     sendin\hich\af2\dbch\af31505\loch\f2 g to ITGroup@domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tl\hich\af2\dbch\af31505\loch\f2 d.
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMPTP port 25 and will not use SSL.
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
 \par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
@@ -1554,15 +1554,15 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 DCDNSInfo       = True
+\par \hich\af2\dbch\af31505\loch\f2     Set the follo\hich\af2\dbch\af31505\loch\f2 wing parameter values:
+\par \hich\af2\dbch\af31505\loch\f2         DCDNSInfo       = True
 \par \hich\af2\dbch\af31505\loch\f2         GPOInheritance  = True
 \par \hich\af2\dbch\af31505\loch\f2         HardWare        = True
 \par \hich\af2\dbch\af31505\loch\f2         IncludeUserInfo = True
@@ -1691,8 +1691,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000009b
-5053fdded301feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000a09e
+fb153257d401feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_Inventory_V2_ReadMe.rtf
+++ b/ADDS_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -86,10 +86,10 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 {\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}
 {\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
 \levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid2638156\rsid2710199\rsid2974686\rsid3342358\rsid3477011
-\rsid3830441\rsid4281248\rsid4467197\rsid4945864\rsid5767175\rsid5849890\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9838801\rsid10101060\rsid10290913\rsid10902102
-\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid12197314\rsid12343757\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14566444\rsid14697282
-\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
-{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2018\mo4\dy5\hr7\min6}{\version40}{\edmins536}{\nofpages23}{\nofwords7235}{\nofchars41244}{\nofcharsws48383}{\vern55}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
+\rsid3830441\rsid4281248\rsid4467197\rsid4945864\rsid5720771\rsid5767175\rsid5849890\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8793422\rsid9243658\rsid9252303\rsid9512169\rsid9838801\rsid10101060\rsid10290913
+\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid12197314\rsid12343757\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14566444
+\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}
+{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2018\mo4\dy28\hr9\min29}{\version41}{\edmins538}{\nofpages23}{\nofwords7235}{\nofchars41245}{\nofcharsws48384}{\vern55}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}
 \paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
@@ -138,7 +138,7 @@ NOTE: This script requires PowerShell V3 or later.
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f2\fs22\insrsid8013811 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls4\ilvl1\rin0\lin1440\itap0\pararsid8013811 {\rtlch\fcs1 
 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid8013811 \hich\af37\dbch\af31505\loch\f37 Certificate Authorities
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f2\fs22\insrsid1520287 \hich\af2\dbch\af31505\loch\f2 o\tab}}\pard \ltrpar\ql \fi-360\li1440\ri0\nowidctlpar\wrapdefault\faauto\ls4\ilvl1\rin0\lin1440\itap0\pararsid1520287 {\rtlch\fcs1 
-\af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid1520287 \hich\af31506\dbch\af31505\loch\f31506 AD Optional Features
+\af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid1520287 \hich\af31506\dbch\af31505\loch\f31506 AD Optional Fe\hich\af31506\dbch\af31505\loch\f31506 atures
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f2\fs22\insrsid12197314 \hich\af2\dbch\af31505\loch\f2 o\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid12197314 \hich\af31506\dbch\af31505\loch\f31506 Schema Extension Items}{
 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid12197314\charrsid10290913 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid10290913\charrsid10290913 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls4\rin0\lin720\itap0\pararsid10290913 {
@@ -262,7 +262,7 @@ Before we can start using PowerShell to document anything in }{\rtlch\fcs1 \af37
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 1.\tab}}\pard\plain \ltrpar\s17\ql \fi-360\li720\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\rin0\lin720\itap0\pararsid11488686\contextualspace \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 At least one Windows Server 2008 R2 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 or later }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 domain controller.
+\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 do\hich\af37\dbch\af31505\loch\f37 main controller.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 
 At least one Windows 7 SP1 or later computer with the Remote Server Administration Tools (RSAT) installed.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -270,20 +270,19 @@ At least one Windows 7 SP1 or later computer with the Remote Server Administrati
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 
  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=7887" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9200000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff0000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is availab\hich\af37\dbch\af31505\loch\f37 le here, }
-{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
-{\*\datafield 
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d0}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administra\hich\af37\dbch\af31505\loch\f37 tion Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d014}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Too\hich\af37\dbch\af31505\loch\f37 ls for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a64}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a6400}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -291,15 +290,15 @@ At least one Windows 7 SP1 or later computer with the Remote Server Administrati
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff0000000000000900730000000000000000000000000000006300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \par \hich\af37\dbch\af31505\loch\f37 This script was developed using Windows Server 20}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 12}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \hich\af37\dbch\af31505\loch\f37  R2 domain controllers and PowerShell Version }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 5}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-\hich\af37\dbch\af31505\loch\f37 .0. The script was run on several Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 10}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-\hich\af37\dbch\af31505\loch\f37  computers with RSAT}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37  and }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 
-Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5849890 
-\hich\af37\dbch\af31505\loch\f37  The script now requires PowerShell V3 or later.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
+\hich\af37\dbch\af31505\loch\f37 .0. The scr\hich\af37\dbch\af31505\loch\f37 ipt was run on several Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 10}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  computers with RSAT}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37  and }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
+\hich\af37\dbch\af31505\loch\f37 Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid5849890 \hich\af37\dbch\af31505\loch\f37  The script now requires PowerShell V3 or later.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf20\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Script Usage
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
@@ -310,8 +309,8 @@ Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af
 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventor}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 y}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2638156 
 \hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 
 \hich\af37\dbch\af31505\loch\f37 in your PowerShell scripts folder.
-\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 From the \hich\af37\dbch\af31505\loch\f37 
-PowerShell prompt, change to your PowerShell scripts}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13133162 \hich\af37\dbch\af31505\loch\f37  folder}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
+\par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell \hich\af37\dbch\af31505\loch\f37 
+prompt, change to your PowerShell scripts}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13133162 \hich\af37\dbch\af31505\loch\f37  folder}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 3.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, type in:
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \ai\af0\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 a.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls3\ilvl1\rin0\lin1440\itap0\pararsid11488686\contextualspace {\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11602030 .\\}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid2638156 
@@ -352,14 +351,14 @@ PDF option, a PDF file is created named after the }{\rtlch\fcs1 \af37\afs22 \ltr
 \par }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 Get-Help .\\}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2638156 \hich\af37\dbch\af31505\loch\f37 ADDS_Inventory_V2}{\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11488686 \hich\af37\dbch\af31505\loch\f37 .ps1 \hich\f37 \endash \loch\f37 full
 \par 
-\par \hich\af37\dbch\af31505\loch\f37 The help text explains all the param\hich\af37\dbch\af31505\loch\f37 eters the script accepts.
+\par \hich\af37\dbch\af31505\loch\f37 The help text explains all the parameters the script accepts.
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid10945524 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf20\insrsid10945524 \hich\af43\dbch\af31505\loch\f43 Help Text
 \par }\pard\plain \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10945524 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \af0 
 \ltrch\fcs0 \insrsid10945524 
 \par }\pard \ltrpar\s19\ql \li0\ri0\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10902102 {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 NAME
-\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2 PSScripts}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \\\hich\af2\dbch\af31505\loch\f2 
-ADDS_Inventory_V2.ps1
+\par \hich\af2\dbch\af31505\loch\f2     C:\\}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2 PSScript\hich\af2\dbch\af31505\loch\f2 s}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \\
+\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 SYNOPSIS
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest.
@@ -374,7 +373,7 @@ ADDS_Inventory_V2.ps1 [-CompanyAddress <String>] [-CompanyEmail }{\rtlch\fcs1 \a
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <String>] [-ADDomain <String>] [-ComputerName <String>] [-DCDNSInfo] [-Folder }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <String>] [-GPOInheritance]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 <S\hich\af2\dbch\af31505\loch\f2 tring>] [-GPOInheritance]}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-Hardware] [-IncludeUserInfo] [-MaxDetails] [-Services] }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 [-Section <Array>] [-Dev] [-ScriptInfo] [-Log] [<CommonParameters>]
@@ -973,20 +972,20 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Pos\hich\af2\dbch\af31505\loch\f2 ition?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to\hich\af2\dbch\af31505\loch\f2  a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text fil\hich\af2\dbch\af31505\loch\f2 e.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    \hich\af2\dbch\af31505\loch\f2 named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -994,7 +993,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    fal\hich\af2\dbch\af31505\loch\f2 se
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -1018,11 +1017,12 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: ADDS_Inventory_V2.ps1
-\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12792789 \hich\af2\dbch\af31505\loch\f2         VERS\hich\af2\dbch\af31505\loch\f2 ION: 2.19}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 
+\par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12792789 \hich\af2\dbch\af31505\loch\f2         VERS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5720771 \hich\af2\dbch\af31505\loch\f2 ION: 2.20}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid10902102\charrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster, Sr. Solutions Architect, Choice Solutions, LLC and Michael }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2         }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13791374 \hich\af2\dbch\af31505\loch\f2 April 5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12792789 \hich\af2\dbch\af31505\loch\f2 , 2018}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13791374 \hich\af2\dbch\af31505\loch\f2 April }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5720771 \hich\af2\dbch\af31505\loch\f2 28}{
+\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12792789 \hich\af2\dbch\af31505\loch\f2 , 2018}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1691,8 +1691,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000f092
-647cd6ccd301feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000009b
+5053fdded301feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_Script_ChangeLog.txt
+++ b/ADDS_Script_ChangeLog.txt
@@ -4,20 +4,29 @@
 #@carlwebster on Twitter
 #http://www.CarlWebster.com
 
-#Version 2.20
+#Version 2.20 28-Sep-2018
 #	Added Domain Functional Level of 7 for Windows Server 2016
 #	Added Forest Functional Level of 7 for Windows Server 2016
 #	Added Domain Schema version 88 for Server 2019 Preview
 #	Added to Domain Information:
 #		Last logon replication interval
 #		Public key required password rolling (2012+)
+#	Added to Forest Information, Domain Controllers:
+#		Operation System
+#		Server Core (Y/N)
 #	Changed "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
 #	Changed all but the Word and HTML arrays from "@() +=" to "New-Object System.Collections.ArrayList .Add()"
 #	Changed the code where I checked for Singletons and -is [array] to use @() around the cmdlets so the result
 #		is always an array. Thanks to fellow CTP Sam Jacobs for the tip. This reduced the code by almost 500 lines.
+#	Changed the functions getting the computer WMI hardware and service info to use 
+#		"New-Object System.Collections.ArrayList .Add()" for Word and HTML tables
+#	Changed the width of the Domain Controllers table to accommodate the new columns
+#	Change the width of the AD Schema Items table to match the other tables
 #	Remove all the duplicate $VarName = $Null from Function ProcessDomains
+#	Reorder Change Log so the most recent is on top and the oldest is at the bottom
 #	Reorder most of the domain properties to be in alphabetical order
 #	Reorder most of the forest properties to be in alphabetical order
+#	Updated Exchange schema version information
 
 #Version 2.19 5-Apr-2018
 #	Added Event Log information to each domain controller and an appendix

--- a/ADDS_Script_ChangeLog.txt
+++ b/ADDS_Script_ChangeLog.txt
@@ -4,6 +4,12 @@
 #@carlwebster on Twitter
 #http://www.CarlWebster.com
 
+#Version 2.20
+#	Added Domain Functional Level of 7 for Windows Server 2016
+#	Added Forest Functional Level of 7 for Windows Server 2016
+#	Change "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
+#	
+
 #Version 2.19 5-Apr-2018
 #	Added Event Log information to each domain controller and an appendix
 #		If the script is run from an elevated PowerShell session by a user with Domain Admin rights

--- a/ADDS_Script_ChangeLog.txt
+++ b/ADDS_Script_ChangeLog.txt
@@ -7,8 +7,17 @@
 #Version 2.20
 #	Added Domain Functional Level of 7 for Windows Server 2016
 #	Added Forest Functional Level of 7 for Windows Server 2016
-#	Change "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
-#	
+#	Added Domain Schema version 88 for Server 2019 Preview
+#	Added to Domain Information:
+#		Last logon replication interval
+#		Public key required password rolling (2012+)
+#	Changed "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
+#	Changed all but the Word and HTML arrays from "@() +=" to "New-Object System.Collections.ArrayList .Add()"
+#	Changed the code where I checked for Singletons and -is [array] to use @() around the cmdlets so the result
+#		is always an array. Thanks to fellow CTP Sam Jacobs for the tip. This reduced the code by almost 500 lines.
+#	Remove all the duplicate $VarName = $Null from Function ProcessDomains
+#	Reorder most of the domain properties to be in alphabetical order
+#	Reorder most of the forest properties to be in alphabetical order
 
 #Version 2.19 5-Apr-2018
 #	Added Event Log information to each domain controller and an appendix


### PR DESCRIPTION
#Version 2.20 28-Sep-2018
#	Added Domain Functional Level of 7 for Windows Server 2016
#	Added Forest Functional Level of 7 for Windows Server 2016
#	Added Domain Schema version 88 for Server 2019 Preview
#	Added to Domain Information:
#		Last logon replication interval
#		Public key required password rolling (2012+)
#	Added to Forest Information, Domain Controllers:
#		Operation System
#		Server Core (Y/N)
#	Changed "renamed" to "changed" as it was freaking people out thinking I was renaming their domain or computer
#	Changed all but the Word and HTML arrays from "@() +=" to "New-Object System.Collections.ArrayList .Add()"
#	Changed the code where I checked for Singletons and -is [array] to use @() around the cmdlets so the result
#		is always an array. Thanks to fellow CTP Sam Jacobs for the tip. This reduced the code by almost 500 lines.
#	Changed the functions getting the computer WMI hardware and service info to use 
#		"New-Object System.Collections.ArrayList .Add()" for Word and HTML tables
#	Changed the width of the Domain Controllers table to accommodate the new columns
#	Change the width of the AD Schema Items table to match the other tables
#	Remove all the duplicate $VarName = $Null from Function ProcessDomains
#	Reorder Change Log so the most recent is on top and the oldest is at the bottom
#	Reorder most of the domain properties to be in alphabetical order
#	Reorder most of the forest properties to be in alphabetical order
#	Updated Exchange schema version information