### PR TITLE
Final update for 2.24

### DIFF
--- a/2.24ReadMe
+++ b/2.24ReadMe
@@ -1,0 +1,9 @@
+#Version 2.24 13-Feb-2020
+#	Fixed several variable name typos
+#	General code cleanup
+#	Updated the following Exchange Schema Versions:
+#		"15312" = "Exchange 2013 CU7 through CU23"
+#		"15317" = "Exchange 2016 Preview and RTM"
+#		"15332" = "Exchange 2016 CU7 through CU15"
+#		"17000" = "Exchange 2019 RTM/CU1"
+#		"17001" = "Exchange 2019 CU2-CU4"

--- a/ADDS_Inventory_V2.ps1
+++ b/ADDS_Inventory_V2.ps1
@@ -802,9 +802,9 @@
 	No objects are output from this script.  This script creates a Word or PDF document.
 .NOTES
 	NAME: ADDS_Inventory_V2.ps1
-	VERSION: 2.23
+	VERSION: 2.24
 	AUTHOR: Carl Webster and Michael B. Smith
-	LASTEDIT: December 17, 2019
+	LASTEDIT: February 13, 2020
 #>
 
 
@@ -959,6 +959,16 @@ Param(
 #Version 1.0 released to the community on May 31, 2014
 #
 #Version 2.0 is based on version 1.20
+#
+#Version 2.24 13-Feb-2020
+#	Fixed several variable name typos
+#	General code cleanup
+#	Updated the following Exchange Schema Versions:
+#		"15312" = "Exchange 2013 CU7 through CU23"
+#		"15317" = "Exchange 2016 Preview and RTM"
+#		"15332" = "Exchange 2016 CU7 through CU15"
+#		"17000" = "Exchange 2019 RTM/CU1"
+#		"17001" = "Exchange 2019 CU2-CU4"
 #
 #Version 2.23 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
@@ -8329,7 +8339,7 @@ Function ProcessSiteInformation
 				#build array of connect objects
 				Write-Verbose "$(Get-Date): `t`t`tProcessing automatic connection objects"
 				$Connections = New-Object System.Collections.ArrayList
-				$ConnnectionObjects = $Null
+				$ConnectionObjects = $Null
 				$ConnectionObjects = Get-ADObject -Filter 'objectClass -eq "nTDSConnection" -and options -bor 1' -Searchbase $Script:ConfigNC -Property DistinguishedName, fromServer -Server $ADForest -EA 0
 				
 				If($? -and $Null -ne $ConnectionObjects)
@@ -8590,7 +8600,7 @@ Function ProcessSiteInformation
 				#build array of connect objects
 				Write-Verbose "$(Get-Date): `t`t`tProcessing automatic connection objects"
 				$Connections = New-Object System.Collections.ArrayList
-				$ConnnectionObjects = $Null
+				$ConnectionObjects = $Null
 				$ConnectionObjects = Get-ADObject -Filter 'objectClass -eq "nTDSConnection" -and options -bor 1' `
 				-Searchbase $Script:ConfigNC -Property DistinguishedName, fromServer -Server $ADForest -EA 0
 				
@@ -8840,7 +8850,7 @@ Function ProcessSiteInformation
 				#build array of connect objects
 				Write-Verbose "$(Get-Date): `t`t`tProcessing automatic connection objects"
 				$Connections = New-Object System.Collections.ArrayList
-				$ConnnectionObjects = $Null
+				$ConnectionObjects = $Null
 				$ConnectionObjects = Get-ADObject -Filter 'objectClass -eq "nTDSConnection" -and options -bor 1' `
 				-Searchbase $Script:ConfigNC -Property DistinguishedName, fromServer -Server $ADForest -EA 0
 				
@@ -9050,14 +9060,15 @@ Function ProcessDomains
 	"15292" = "Exchange 2013 SP1/CU4";
 	"15300" = "Exchange 2013 CU5";
 	"15303" = "Exchange 2013 CU6";
-	"15312" = "Exchange 2013 CU7 through CU 21"; #updated in 2.20
-	"15317" = "Exchange 2016";
+	"15312" = "Exchange 2013 CU7 through CU23"; #updated in 2.20, updated in 2.24
+	"15317" = "Exchange 2016 Preview and RTM"; #updated in 2.24
 	"15323" = "Exchange 2016 CU1";
 	"15325" = "Exchange 2016 CU2";
 	"15326" = "Exchange 2016 CU3/CU4/CU5"; #added in 2.16
 	"15330" = "Exchange 2016 CU6"; #added in 2.16
-	"15332" = "Exchange 2016 CU7 through CU11"; #added in 2.16 and updated in 2.20, updated in 2.22
-	"17000" = "Exchange 2019 RTM"; #added in 2.22
+	"15332" = "Exchange 2016 CU7 through CU15"; #added in 2.16 and updated in 2.20, updated in 2.22, updated in 2.24
+	"17000" = "Exchange 2019 RTM/CU1"; #added in 2.22, updated in 2.24
+	"17001" = "Exchange 2019 CU2-CU4"; #added in 2.24
 	}
 
 	ForEach($Domain in $Script:Domains)
@@ -10451,18 +10462,18 @@ Function ProcessDomains
 			}
 		}
 	}
-	$ADDomainTrusts = $Null
-	$ADSchemaInfo = $Null
-	$ChildDomains = $Null
-	$DNSSuffixes = $Null
-	$DomainControllers = $Null
-	$ExchangeSchemaInfo = $Null
-	$FGPPs = $Null
-	$First = $Null
-	$ReadOnlyReplicas = $Null
-	$Replicas = $Null
+	$ADDomainTrusts        = $Null
+	$ADSchemaInfo          = $Null
+	$ChildDomains          = $Null
+	$DNSSuffixes           = $Null
+	$DomainControllers     = $Null
+	$ExchangeSchemaInfo    = $Null
+	$FGPPs                 = $Null
+	$First                 = $Null
+	$ReadOnlyReplicas      = $Null
+	$Replicas              = $Null
 	$SubordinateReferences = $Null
-	$Table = $Null
+	$Table                 = $Null
 }
 #endregion
 
@@ -10973,14 +10984,14 @@ Function OutputTimeServerRegistryKeys
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\NtpClient	SpecialPollInterval
 	#HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\VMICTimeProvider Enabled
 	
-	$AnnounceFlags = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Config" "AnnounceFlags" $DCName
-	$MaxNegPhaseCorrection = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Config" "MaxNegPhaseCorrection" $DCName
-	$MaxPosPhaseCorrection = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Config" "MaxPosPhaseCorrection" $DCName
-	$NtpServer = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Parameters" "NtpServer" $DCName
-	$NtpType = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Parameters" "Type" $DCName
-	$SpecialPollInterval = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\NtpClient" "SpecialPollInterval" $DCName
+	$AnnounceFlags           = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Config" "AnnounceFlags" $DCName
+	$MaxNegPhaseCorrection   = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Config" "MaxNegPhaseCorrection" $DCName
+	$MaxPosPhaseCorrection   = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Config" "MaxPosPhaseCorrection" $DCName
+	$NtpServer               = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Parameters" "NtpServer" $DCName
+	$NtpType                 = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\Parameters" "Type" $DCName
+	$SpecialPollInterval     = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\NtpClient" "SpecialPollInterval" $DCName
 	$VMICTimeProviderEnabled = Get-RegistryValue "HKLM:\SYSTEM\CurrentControlSet\Services\W32Time\TimeProviders\VMICTimeProvider" "Enabled" $DCName
-	$NTPSource = w32tm /query /computer:$DCName /source
+	$NTPSource               = w32tm /query /computer:$DCName /source
 	
 	If($VMICTimeProviderEnabled -eq 0)
 	{
@@ -11779,12 +11790,12 @@ Function ProcessGroupInformation
 			
 			Write-Verbose "$(Get-Date): `t`tGetting counts"
 			
-			[int]$SecurityCount = 0
-			[int]$DistributionCount = 0
-			[int]$GlobalCount = 0
-			[int]$UniversalCount = 0
-			[int]$DomainLocalCount = 0
-			[int]$ContactsCount = 0
+			[int]$SecurityCount        = 0
+			[int]$DistributionCount    = 0
+			[int]$GlobalCount          = 0
+			[int]$UniversalCount       = 0
+			[int]$DomainLocalCount     = 0
+			[int]$ContactsCount        = 0
 			[int]$GroupsWithSIDHistory = 0
 			
 			Write-Verbose "$(Get-Date): `t`t`tSecurity Groups"
@@ -11831,14 +11842,14 @@ Function ProcessGroupInformation
 
 			[int]$ContactsCount = $Results.Count
 
-			[string]$TotalCountStr = "{0,7:N0}" -f ($SecurityCount + $DistributionCount)
-			[string]$SecurityCountStr = "{0,7:N0}" -f $SecurityCount
-			[string]$DomainLocalCountStr = "{0,7:N0}" -f $DomainLocalCount
-			[string]$GlobalCountStr = "{0,7:N0}" -f $GlobalCount
-			[string]$UniversalCountStr = "{0,7:N0}" -f $UniversalCount
-			[string]$DistributionCountStr = "{0,7:N0}" -f $DistributionCount
+			[string]$TotalCountStr           = "{0,7:N0}" -f ($SecurityCount + $DistributionCount)
+			[string]$SecurityCountStr        = "{0,7:N0}" -f $SecurityCount
+			[string]$DomainLocalCountStr     = "{0,7:N0}" -f $DomainLocalCount
+			[string]$GlobalCountStr          = "{0,7:N0}" -f $GlobalCount
+			[string]$UniversalCountStr       = "{0,7:N0}" -f $UniversalCount
+			[string]$DistributionCountStr    = "{0,7:N0}" -f $DistributionCount
 			[string]$GroupsWithSIDHistoryStr = "{0,7:N0}" -f $GroupsWithSIDHistory
-			[string]$ContactsCountStr = "{0,7:N0}" -f $ContactsCount
+			[string]$ContactsCountStr        = "{0,7:N0}" -f $ContactsCount
 			
 			Write-Verbose "$(Get-Date): `t`tBuild groups table"
 			If($MSWORD -or $PDF)
@@ -11939,15 +11950,15 @@ Function ProcessGroupInformation
 			
 			If($? -and $Null -ne $DomainInfo)
 			{
-				$DomainAdminsSID = "$($DomainInfo.DomainSID)-512"
+				$DomainAdminsSID     = "$($DomainInfo.DomainSID)-512"
 				$EnterpriseAdminsSID = "$($DomainInfo.DomainSID)-519"
-				$SchemaAdminsSID = "$($DomainInfo.DomainSID)-518"
+				$SchemaAdminsSID     = "$($DomainInfo.DomainSID)-518"
 			}
 			Else
 			{
-				$DomainAdminsSID = $Null
+				$DomainAdminsSID     = $Null
 				$EnterpriseAdminsSID = $Null
-				$SchemaAdminsSID = $Null
+				$SchemaAdminsSID     = $Null
 			}
 			
 			Write-Verbose "$(Get-Date): `t`tListing domain admins"
@@ -12946,7 +12957,7 @@ Function ProcessGroupInformation
 			#http://www.shariqsheikh.com/blog/index.php/200908/use-powershell-to-look-up-admincount-from-adminsdholder-and-sdprop/		
 			Write-Verbose "$(Get-Date): `t`tListing users with AdminCount=1"
 			#V2.20 changed to @()
-			$AdminCounts = @(Get-ADUser -LDAPFilter "(admincount=1)"  -Server $Domain -EA 0)
+			$AdminCounts = @(Get-ADUser -LDAPFilter "(admincount=1)" -Server $Domain -EA 0)
 			
 			If($? -and $Null -ne $AdminCounts)
 			{
@@ -14445,7 +14456,7 @@ Function ProcessMiscDataByDomain
 				#2.16
 				Write-Verbose "$(Get-Date): `t`t`tAll users with Homedrive set in ADUC"
 				#V2.20 changed to @()
-				$HomeDriveUsers = @($Users | Where-Object {$_.HomeDrive -ne $Null})
+				$HomeDriveUsers = @($Users | Where-Object {$Null -ne $_.HomeDrive}) #fixed in 2.24
 			
 				[int]$UsersHomeDrivecnt = $HomeDriveUsers.Count
 				
@@ -14502,44 +14513,44 @@ Function ProcessMiscDataByDomain
 			}
 			Else
 			{
-				[int]$UsersCount = 0
-				[int]$UsersDisabledcnt = 0
-				[int]$UsersLockedOutcnt = 0
-				[int]$UsersPasswordExpiredcnt = 0
-				[int]$UsersPasswordNeverExpirescnt = 0
-				[int]$UsersPasswordNotRequiredcnt = 0
-				[int]$UsersCannotChangePasswordcnt = 0
-				[int]$UsersWithSIDHistorycnt = 0
-				[int]$UsersHomeDrivecnt = 0
-				[int]$UsersPrimaryGroupcnt = 0
-				[int]$UsersRDSHomeDrivecnt = 0
-				[int]$ActiveUsersCountcnt = 0
-				[int]$ActiveUsersPasswordExpiredcnt = 0
-				[int]$ActiveUsersPasswordNeverExpirescnt = 0
-				[int]$ActiveUsersPasswordNotRequiredcnt = 0
-				[int]$ActiveUsersCannotChangePasswordcnt = 0
-				[int]$ActiveUserslastLogonTimestampcnt = 0
+				[int]$UsersCount                      = 0
+				[int]$UsersDisabledcnt                = 0
+				[int]$UsersLockedOutcnt               = 0
+				[int]$UsersPasswordExpiredcnt         = 0
+				[int]$UsersPasswordNeverExpirescnt    = 0
+				[int]$UsersPasswordNotRequiredcnt     = 0
+				[int]$UsersCannotChangePasswordcnt    = 0
+				[int]$UsersWithSIDHistorycnt          = 0
+				[int]$UsersHomeDrivecnt               = 0
+				[int]$UsersPrimaryGroupcnt            = 0
+				[int]$UsersRDSHomeDrivecnt            = 0
+				[int]$ActiveUsersCount                = 0 #fixed 2.24
+				[int]$ActiveUsersPasswordExpired      = 0 #fixed 2.24
+				[int]$ActiveUsersPasswordNeverExpires = 0 #fixed 2.24
+				[int]$ActiveUsersPasswordNotRequired  = 0 #fixed 2.24
+				[int]$ActiveUsersCannotChangePassword = 0 #fixed 2.24
+				[int]$ActiveUserslastLogonTimestamp   = 0 #fixed 2.24
 			}
 
 			Write-Verbose "$(Get-Date): `t`tFormat numbers into strings"
-			[string]$UsersCountStr = "{0,7:N0}" -f $UsersCount
-			[string]$UsersDisabledStr = "{0,7:N0}" -f $UsersDisabledcnt
-			[string]$UsersUnknownStr = "{0,7:N0}" -f $UsersUnknowncnt
-			[string]$UsersLockedOutStr = "{0,7:N0}" -f $UsersLockedOutcnt
-			[string]$UsersPasswordExpiredStr = "{0,7:N0}" -f $UsersPasswordExpiredcnt
-			[string]$UsersPasswordNeverExpiresStr = "{0,7:N0}" -f $UsersPasswordNeverExpirescnt
-			[string]$UsersPasswordNotRequiredStr = "{0,7:N0}" -f $UsersPasswordNotRequiredcnt
-			[string]$UsersCannotChangePasswordStr = "{0,7:N0}" -f $UsersCannotChangePasswordcnt
-			[string]$UsersWithSIDHistoryStr = "{0,7:N0}" -f $UsersWithSIDHistorycnt
-			[string]$UsersHomeDriveStr = "{0,7:N0}" -f $UsersHomeDrivecnt
-			[string]$UsersPrimaryGroupStr = "{0,7:N0}" -f $UsersPrimaryGroupcnt
-			[string]$UsersRDSHomeDriveStr = "{0,7:N0}" -f $UsersRDSHomeDrivecnt
-			[string]$ActiveUsersCountStr = "{0,7:N0}" -f $ActiveUsersCount
-			[string]$ActiveUsersPasswordExpiredStr = "{0,7:N0}" -f $ActiveUsersPasswordExpired
+			[string]$UsersCountStr                      = "{0,7:N0}" -f $UsersCount
+			[string]$UsersDisabledStr                   = "{0,7:N0}" -f $UsersDisabledcnt
+			[string]$UsersUnknownStr                    = "{0,7:N0}" -f $UsersUnknowncnt
+			[string]$UsersLockedOutStr                  = "{0,7:N0}" -f $UsersLockedOutcnt
+			[string]$UsersPasswordExpiredStr            = "{0,7:N0}" -f $UsersPasswordExpiredcnt
+			[string]$UsersPasswordNeverExpiresStr       = "{0,7:N0}" -f $UsersPasswordNeverExpirescnt
+			[string]$UsersPasswordNotRequiredStr        = "{0,7:N0}" -f $UsersPasswordNotRequiredcnt
+			[string]$UsersCannotChangePasswordStr       = "{0,7:N0}" -f $UsersCannotChangePasswordcnt
+			[string]$UsersWithSIDHistoryStr             = "{0,7:N0}" -f $UsersWithSIDHistorycnt
+			[string]$UsersHomeDriveStr                  = "{0,7:N0}" -f $UsersHomeDrivecnt
+			[string]$UsersPrimaryGroupStr               = "{0,7:N0}" -f $UsersPrimaryGroupcnt
+			[string]$UsersRDSHomeDriveStr               = "{0,7:N0}" -f $UsersRDSHomeDrivecnt
+			[string]$ActiveUsersCountStr                = "{0,7:N0}" -f $ActiveUsersCount
+			[string]$ActiveUsersPasswordExpiredStr      = "{0,7:N0}" -f $ActiveUsersPasswordExpired
 			[string]$ActiveUsersPasswordNeverExpiresStr = "{0,7:N0}" -f $ActiveUsersPasswordNeverExpires
-			[string]$ActiveUsersPasswordNotRequiredStr = "{0,7:N0}" -f $ActiveUsersPasswordNotRequired
+			[string]$ActiveUsersPasswordNotRequiredStr  = "{0,7:N0}" -f $ActiveUsersPasswordNotRequired
 			[string]$ActiveUsersCannotChangePasswordStr = "{0,7:N0}" -f $ActiveUsersCannotChangePassword
-			[string]$ActiveUserslastLogonTimestampStr = "{0,7:N0}" -f $ActiveUserslastLogonTimestamp
+			[string]$ActiveUserslastLogonTimestampStr   = "{0,7:N0}" -f $ActiveUserslastLogonTimestamp
 
 			If($MSWORD -or $PDF)
 			{

--- a/ADDS_Inventory_V2_ReadMe.rtf
+++ b/ADDS_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -86,13 +86,13 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 {\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}
 {\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
 \levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid2638156\rsid2710199\rsid2974686\rsid3342358\rsid3477011
-\rsid3828116\rsid3830441\rsid4281248\rsid4467197\rsid4945864\rsid5720771\rsid5767175\rsid5849890\rsid6031750\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8793422\rsid9119488\rsid9243658\rsid9252303\rsid9512169
-\rsid9838801\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid11865833\rsid12197314\rsid12343757\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162\rsid13725463
-\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1
-\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2019\mo12\dy17\hr7\min22}{\version47}{\edmins544}{\nofpages23}{\nofwords7227}{\nofchars41199}{\nofcharsws48330}{\vern119}}
+\rsid3828116\rsid3830441\rsid4281248\rsid4467197\rsid4665378\rsid4945864\rsid5720771\rsid5767175\rsid5849890\rsid6031750\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8793422\rsid9119488\rsid9243658\rsid9252303
+\rsid9512169\rsid9838801\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid11865833\rsid12197314\rsid12343757\rsid12792789\rsid12848963\rsid12856395\rsid12916989\rsid13133162
+\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0
+\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo2\dy13\hr9\min52}{\version48}{\edmins545}{\nofpages23}{\nofwords7227}{\nofchars41199}{\nofcharsws48330}{\vern123}}
 {\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwqwUA50MMhCwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
@@ -271,19 +271,19 @@ At least one Windows 7 SP1 or later computer with the Remote Server Administrati
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 
  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=7887" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9200000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff0000600000300000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff000060000030000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d0146d0e00010000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration \hich\af37\dbch\af31505\loch\f37 Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d0146d0e0001000098}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration\hich\af37\dbch\af31505\loch\f37  Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a64006d0000006300}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a64006d0000006300c8}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -291,7 +291,7 @@ At least one Windows 7 SP1 or later computer with the Remote Server Administrati
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c0000000000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c000000000036}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \par \hich\af37\dbch\af31505\loch\f37 This script was developed using Windows Server 20}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 12}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
@@ -482,28 +482,28 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         http://www.microsoft.com/en-us/download/details.aspx?id=45520
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
+\par \hich\af2\dbch\af31505\loch\f2 PARA\hich\af2\dbch\af31505\loch\f2 METERS
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Add\hich\af2\dbch\af31505\loch\f2 ress to use for the Cover Page, if the Cover Page has the Address field.
+\par \hich\af2\dbch\af31505\loch\f2         Company Address to use for the Cover Page, if the Cover Page has the Address field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word\hich\af2\dbch\af31505\loch\f2  2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Filigree (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            ViewMaster (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This pa\hich\af2\dbch\af31505\loch\f2 rameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Default value
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail <String>
@@ -512,24 +512,24 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Email field:
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output para\hich\af2\dbch\af31505\loch\f2 meters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CE.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyFax <String>
-\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the \hich\af2\dbch\af31505\loch\f2 Fax field.
+\par \hich\af2\dbch\af31505\loch\f2     -Comp\hich\af2\dbch\af31505\loch\f2 anyFax <String>
+\par \hich\af2\dbch\af31505\loch\f2         Company Fax to use for the Cover Page, if the Cover Page has the Fax field.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Fax field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias o\hich\af2\dbch\af31505\loch\f2 f CF.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is on\hich\af2\dbch\af31505\loch\f2 ly valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CF.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -540,28 +540,28 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Name to use for the Cover Page.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in
-\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName or
+\par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompanyName or
 \par \hich\af2\dbch\af31505\loch\f2         HKCU:\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company, whichever is populated
-\par \hich\af2\dbch\af31505\loch\f2         on \hich\af2\dbch\af31505\loch\f2 the computer running the script.
+\par \hich\af2\dbch\af31505\loch\f2         on the computer running the script.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CN.
-\par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is not specified, the report
+\par \hich\af2\dbch\af31505\loch\f2         If either registry key does not exist and this parameter is\hich\af2\dbch\af31505\loch\f2  not specified, the report
 \par \hich\af2\dbch\af31505\loch\f2         will not contain a Company Name on the cover page.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is o\hich\af2\dbch\af31505\loch\f2 nly valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Co\hich\af2\dbch\af31505\loch\f2 mpanyPhone <String>
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone <String>
 \par \hich\af2\dbch\af31505\loch\f2         Company Phone to use for the Cover Page if the Cover Page has the Phone field.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have a Phone field:
+\par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages h\hich\af2\dbch\af31505\loch\f2 ave a Phone field:
 \par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This parame\hich\af2\dbch\af31505\loch\f2 ter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CPh.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
@@ -570,52 +570,52 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <String>
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage <\hich\af2\dbch\af31505\loch\f2 String>
 \par \hich\af2\dbch\af31505\loch\f2         What Microsoft Word Cover Page to use.
 \par \hich\af2\dbch\af31505\loch\f2         Only Word 2010, 2013 and 2016 are supported.
 \par \hich\af2\dbch\af31505\loch\f2         (default cover pages in Word en-US)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Valid input is:
 \par \hich\af2\dbch\af31505\loch\f2                 Alphabet (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. Doesn't work well for this report)
+\par \hich\af2\dbch\af31505\loch\f2                 Annual (Word 2010. \hich\af2\dbch\af31505\loch\f2 Doesn't work well for this report)
 \par \hich\af2\dbch\af31505\loch\f2                 Austere (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, \hich\af2\dbch\af31505\loch\f2 mostly
+\par \hich\af2\dbch\af31505\loch\f2                 Austin (Word 2010/2013/2016. Doesn't work in 2013 or 2016, mostly
 \par \hich\af2\dbch\af31505\loch\f2                 works in 2010 but Subtitle/Subject & Author fields need to be moved
-\par \hich\af2\dbch\af31505\loch\f2                 after title box is moved up)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     after title box is moved up)
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Conservative (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Contrast \hich\af2\dbch\af31505\loch\f2 (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Contrast (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Cubicles (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Works if you like looking sideways)
+\par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010. Wor\hich\af2\dbch\af31505\loch\f2 ks if you like looking sideways)
 \par \hich\af2\dbch\af31505\loch\f2                 Facet (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Grid (Wor\hich\af2\dbch\af31505\loch\f2 d 2010/2013/2016. Works in 2010)
+\par \hich\af2\dbch\af31505\loch\f2                 Grid (Word 2010/2013/2016. Works in 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 manually resiz\hich\af2\dbch\af31505\loch\f2 ed or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Motion (Word 2010/2013/2016. Works if top date is manually changed to
+\par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010.\hich\af2\dbch\af31505\loch\f2  Works)
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Perspective (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
 \par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Wor\hich\af2\dbch\af31505\loch\f2 d 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
+\par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Work\hich\af2\dbch\af31505\loch\f2 s)
+\par \hich\af2\dbch\af31505\loch\f2                 Sl\hich\af2\dbch\af31505\loch\f2 ice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Wor\hich\af2\dbch\af31505\loch\f2 ks)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The default value is Si\hich\af2\dbch\af31505\loch\f2 deline.
+\par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
@@ -626,28 +626,28 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Default value is contained in $env:username
+\par \hich\af2\dbch\af31505\loch\f2         Use\hich\af2\dbch\af31505\loch\f2 rname to use for the Cover Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    na\hich\af2\dbch\af31505\loch\f2 med
+\par \hich\af2\dbch\af31505\loch\f2         Required?                   \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disa\hich\af2\dbch\af31505\loch\f2 bled by default.
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .\hich\af2\dbch\af31505\loch\f2 html extension.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildc\hich\af2\dbch\af31505\loch\f2 ard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchPa\hich\af2\dbch\af31505\loch\f2 rameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is set True if no other output format is selected.
 \par 
@@ -659,20 +659,20 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?      \hich\af2\dbch\af31505\loch\f2               named
+\par \hich\af2\dbch\af31505\loch\f2         Required?      \hich\af2\dbch\af31505\loch\f2               false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
-\par \hich\af2\dbch\af31505\loch\f2         This pa\hich\af2\dbch\af31505\loch\f2 rameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text \hich\af2\dbch\af31505\loch\f2 file with a .txt extension.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -716,13 +716,13 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?   \hich\af2\dbch\af31505\loch\f2     false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Specifies an Active Directory domain object by providing one of the following
+\par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
 \par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in parentheses is the LDAP display name for the
-\par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the domain.
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    attribute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
 \par 
@@ -732,9 +732,9 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Example: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Security Identifier (objectSid)
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Security Identifier (objectSid)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: S-1-5-21-3643273344-15054\hich\af2\dbch\af31505\loch\f2 09314-3732760578
+\par \hich\af2\dbch\af31505\loch\f2         Example: S-1-5-21-3643273344-1505409314-3732760578
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         DNS domain name
 \par 
@@ -893,15 +893,15 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <Array>
-\par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections of the report.
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Valid options are:
+\par \hich\af2\dbch\af31505\loch\f2         Processes o\hich\af2\dbch\af31505\loch\f2 ne or more sections of the report.
+\par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Forest
 \par \hich\af2\dbch\af31505\loch\f2                 Sites
 \par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers and optional Hardware, Services and
 \par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
-\par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
+\par \hich\af2\dbch\af31505\loch\f2                 OUs (Organization\hich\af2\dbch\af31505\loch\f2 al Units)
 \par \hich\af2\dbch\af31505\loch\f2                 Groups
-\par \hich\af2\dbch\af31505\loch\f2           \hich\af2\dbch\af31505\loch\f2       GPOs
+\par \hich\af2\dbch\af31505\loch\f2                 GPOs
 \par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
 \par \hich\af2\dbch\af31505\loch\f2                 All
 \par 
@@ -909,30 +909,30 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated by a comma. -Section forest, domains
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Pos\hich\af2\dbch\af31505\loch\f2 ition?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Req\hich\af2\dbch\af31505\loch\f2 uired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                All
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
-\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional em\hich\af2\dbch\af31505\loch\f2 ail server to send the output report.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters\hich\af2\dbch\af31505\loch\f2 ?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2        Specifies the SMTP port.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                25
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard cha\hich\af2\dbch\af31505\loch\f2 racters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       \hich\af2\dbch\af31505\loch\f2 false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
@@ -940,7 +940,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value            \hich\af2\dbch\af31505\loch\f2     False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -951,7 +951,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inpu\hich\af2\dbch\af31505\loch\f2 t?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
@@ -959,16 +959,16 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accep\hich\af2\dbch\af31505\loch\f2 t pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text fil\hich\af2\dbch\af31505\loch\f2 e at the end of the script.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This is used when the \hich\af2\dbch\af31505\loch\f2 script developer requests more troubleshooting data.
+\par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
@@ -977,23 +977,23 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Outputs information about the script to a text file.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter\hich\af2\dbch\af31505\loch\f2  has an alias of SI.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?         \hich\af2\dbch\af31505\loch\f2            false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for trou\hich\af2\dbch\af31505\loch\f2 bleshooting.
+\par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchP\hich\af2\dbch\af31505\loch\f2 arameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Generates a log file for troubleshooting.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -1020,11 +1020,11 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: ADDS_Inventory_V2.ps1
 \par }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid12792789 \hich\af2\dbch\af31505\loch\f2         VERS}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid5720771 \hich\af2\dbch\af31505\loch\f2 ION: 2.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
-\f2\fs18\insrsid6031750 \hich\af2\dbch\af31505\loch\f2 3}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 
+\f2\fs18\insrsid4665378 \hich\af2\dbch\af31505\loch\f2 4}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid9119488 \hich\af2\dbch\af31505\loch\f2  }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 
-\hich\af2\dbch\af31505\loch\f2 and Michael \hich\af2\dbch\af31505\loch\f2 B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid6031750 \hich\af2\dbch\af31505\loch\f2 December 1}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11865833 \hich\af2\dbch\af31505\loch\f2 7}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid3828116 \hich\af2\dbch\af31505\loch\f2 , 2019}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 
+\hich\af2\dbch\af31505\loch\f2 and Michael B. Smith
+\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4665378 \hich\af2\dbch\af31505\loch\f2 February 13, 20\hich\af2\dbch\af31505\loch\f2 20}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
+\f2\fs18\insrsid10902102\charrsid10902102 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
@@ -1184,20 +1184,20 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 8 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -HTML -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -HTML -ADForest corp.carl\hich\af2\dbch\af31505\loch\f2 webster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as an HTML file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="C\hich\af2\dbch\af31505\loch\f2 arl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    corp.carlwebster.com for the AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env\hich\af2\dbch\af31505\loch\f2 :USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1206,47 +1206,47 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 9 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -hardware
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\\hich\af2\dbch\af31505\loch\f2 PSScript >.\\ADDS_Inventory_V2.ps1 -hardware
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for each domain controller
 \par \hich\af2\dbch\af31505\loch\f2     about its hardware.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_U\hich\af2\dbch\af31505\loch\f2 SER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline f\hich\af2\dbch\af31505\loch\f2 or the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a glob\hich\af2\dbch\af31505\loch\f2 al catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 10 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -services
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional infor\hich\af2\dbch\af31505\loch\f2 mation for the services running
-\par \hich\af2\dbch\af31505\loch\f2     on each domain controller.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
+\par \hich\af2\dbch\af31505\loch\f2     ADForest de\hich\af2\dbch\af31505\loch\f2 faults to the value of $Env:USERDNSDOMAIN.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par 
+\par 
+\par 
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -------------------------- EXAMPLE 10 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -services
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for the services running
+\par \hich\af2\dbch\af31505\loch\f2     on each domain controller.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Na\hich\af2\dbch\af31505\loch\f2 me.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defa\hich\af2\dbch\af31505\loch\f2 ults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller t\hich\af2\dbch\af31505\loch\f2 hat is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
@@ -1256,11 +1256,11 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -DCDNSInfo
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and add additional information for each domain controller
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and a\hich\af2\dbch\af31505\loch\f2 dd additional information for each domain controller
 \par \hich\af2\dbch\af31505\loch\f2     about its DNS IP configuration.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyNa\hich\af2\dbch\af31505\loch\f2 me="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Compa\hich\af2\dbch\af31505\loch\f2 ny="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1270,8 +1270,8 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMA\hich\af2\dbch\af31505\loch\f2 IN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global\hich\af2\dbch\af31505\loch\f2  catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
@@ -1279,44 +1279,44 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 12 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inv\hich\af2\dbch\af31505\loch\f2 entory_V2.ps1 -CompanyName "Carl Webster Consulting"
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -UserName "Carl Webster" -ComputerName ADDC01
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V2.ps1 -CompanyName "Carl Webster Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage "Mod" -Us\hich\af2\dbch\af31505\loch\f2 erName "Carl Webster" -ComputerName ADDC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
 \par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the\hich\af2\dbch\af31505\loch\f2  User Name.
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         ADForest defaults to the value of $Env:USERDNSDOMAIN.
-\par \hich\af2\dbch\af31505\loch\f2         Domain Controller named ADDC01 for the ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      Domain Controller named ADDC01 for the ComputerName.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 13 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod"
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V2.ps1 -CN "Carl Webster Consulting" -CP "Mod"
 \par \hich\af2\dbch\af31505\loch\f2     -UN "Carl Webster"
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alia\hich\af2\dbch\af31505\loch\f2 s CN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster Consulting for the Company Name (alias CN).
 \par \hich\af2\dbch\af31505\loch\f2         Mod for the Cover Page format (alias CP).
-\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (alias UN).
+\par \hich\af2\dbch\af31505\loch\f2         Carl Webster for the User Name (a\hich\af2\dbch\af31505\loch\f2 lias UN).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries fo\hich\af2\dbch\af31505\loch\f2 r
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     value \hich\af2\dbch\af31505\loch\f2 for ComputerName.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 14 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V2.ps1 -CompanyName "Sh\hich\af2\dbch\af31505\loch\f2 erlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V2.ps1 -CompanyName "Sherlock Holmes
 \par \hich\af2\dbch\af31505\loch\f2     Consulting"
 \par \hich\af2\dbch\af31505\loch\f2     -CoverPage Exposure -UserName "Dr. Watson"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "221B Baker Street, London, England"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyAddress "\hich\af2\dbch\af31505\loch\f2 221B Baker Street, London, England"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyFax "+44 1753 276600"
 \par \hich\af2\dbch\af31505\loch\f2     -CompanyPhone "+44 1753 276200"
 \par 
@@ -1326,31 +1326,9 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2         221B Baker Street, London, England for the Company Address.
 \par \hich\af2\dbch\af31505\loch\f2         +44 1753 276600 for the Company Fax.
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     +44 1753 276200 for the Company Phone.
+\par \hich\af2\dbch\af31505\loch\f2         +44 1753 276200 for the Company Phone.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server an\hich\af2\dbch\af31505\loch\f2 d will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
-\par 
-\par 
-\par 
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 15 --------------------------
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V2.ps1 -CompanyName "Sherlock Holmes
-\par \hich\af2\dbch\af31505\loch\f2     Consulting"
-\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr.\hich\af2\dbch\af31505\loch\f2  Watson"
-\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use:
-\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the \hich\af2\dbch\af31505\loch\f2 Company Email.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
+\par \hich\af2\dbch\af31505\loch\f2     ADForest \hich\af2\dbch\af31505\loch\f2 defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
@@ -1359,24 +1337,46 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par 
 \par 
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -------------------------- EXAMPLE 15 --------------------------
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\>PS C:\\PSScript .\\ADDS_Inventory_V2.ps1 -CompanyName "Sherlock Holmes
+\par \hich\af2\dbch\af31505\loch\f2     Consulting"
+\par \hich\af2\dbch\af31505\loch\f2     -CoverPage Facet -UserName "Dr. Watson"
+\par \hich\af2\dbch\af31505\loch\f2     -CompanyEmail SuperSleuth@SherlockHolmes.com
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     Will use:
+\par \hich\af2\dbch\af31505\loch\f2         Sherlock Holmes Consulting for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2         Facet for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2         Dr. Watson for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2         SuperSleuth@SherlockHolmes.com for the Company Email.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     value for Compute\hich\af2\dbch\af31505\loch\f2 rName.
+\par 
+\par 
+\par 
+\par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 16 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest company.tld -A\hich\af2\dbch\af31505\loch\f2 ddDateTime
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest company.tld -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInf\hich\af2\dbch\af31505\loch\f2 o\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Admini\hich\af2\dbch\af31505\loch\f2 strator.
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator \hich\af2\dbch\af31505\loch\f2 for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     value for ComputerNam\hich\af2\dbch\af31505\loch\f2 e.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
@@ -1390,25 +1390,25 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 17 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V2.ps1 -PDF -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -PDF -ADForest corp.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_US\hich\af2\dbch\af31505\loch\f2 ER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for\hich\af2\dbch\af31505\loch\f2  the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for t\hich\af2\dbch\af31505\loch\f2 he AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server\hich\af2\dbch\af31505\loch\f2  and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the en\hich\af2\dbch\af31505\loch\f2 d of the file name.
+\par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2     The timestamp is in the format of yyyy-MM-dd_HHmm.
 \par \hich\af2\dbch\af31505\loch\f2     June 1, }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11865833 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 
  at 6PM is }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid11865833 \hich\af2\dbch\af31505\loch\f2 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 -06-01_1800.
@@ -1423,19 +1423,19 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest corp.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -Folder \\\\FileServer\\ShareName
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\O\hich\af2\dbch\af31505\loch\f2 ffice\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     C\hich\af2\dbch\af31505\loch\f2 arl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as t\hich\af2\dbch\af31505\loch\f2 he
+\par \hich\af2\dbch\af31505\loch\f2     a doma\hich\af2\dbch\af31505\loch\f2 in controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The output file will be saved in the path \\\\FileServer\\ShareName.
@@ -1445,29 +1445,29 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 19 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V2.ps1 -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest corp.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mail.domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
-\par \hich\af2\dbch\af31505\loch\f2     -ComputerName Server01
+\par \hich\af2\dbch\af31505\loch\f2     -ComputerName Serve\hich\af2\dbch\af31505\loch\f2 r01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Adminis\hich\af2\dbch\af31505\loch\f2 trator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will be run remotely against server Server01.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
-\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tl\hich\af2\dbch\af31505\loch\f2 d.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the ema\hich\af2\dbch\af31505\loch\f2 il server mail.domain.tld, sending from XDAdmin@domain.tld,
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMPTP port 25 and will not use SSL.
-\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
+\par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be promp\hich\af2\dbch\af31505\loch\f2 ted
 \par \hich\af2\dbch\af31505\loch\f2     to enter valid credentials.
 \par 
 \par 
@@ -1480,24 +1480,24 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL
 \par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
-\par \hich\af2\dbch\af31505\loch\f2     -To ITGr\hich\af2\dbch\af31505\loch\f2 oup@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username\hich\af2\dbch\af31505\loch\f2  = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Offic\hich\af2\dbch\af31505\loch\f2 e\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for Compu\hich\af2\dbch\af31505\loch\f2 terName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global c\hich\af2\dbch\af31505\loch\f2 atalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL, sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587\hich\af2\dbch\af31505\loch\f2  using SSL, sending }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 
 \par \hich\af2\dbch\af31505\loch\f2     f}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 rom}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102 \hich\af2\dbch\af31505\loch\f2  }{
 \rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10902102\charrsid10902102 \hich\af2\dbch\af31505\loch\f2 webster@carlwebster.com, sending to ITGroup@carlwebster.com.
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email, the user will be prompted
@@ -1508,12 +1508,12 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 21 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -Section Forest
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -Section Fore\hich\af2\dbch\af31505\loch\f2 st
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserI\hich\af2\dbch\af31505\loch\f2 nfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1522,7 +1522,7 @@ ADDS_Inventory_V2.ps1 [-Text] [-AddDateTime] [-ADForest <String>] }{\rtlch\fcs1 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName de\hich\af2\dbch\af31505\loch\f2 faults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script qu\hich\af2\dbch\af31505\loch\f2 eries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
@@ -1697,8 +1697,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000803e
-effcdcb4d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000080db
+d18885e2d501feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_Script_ChangeLog.txt
+++ b/ADDS_Script_ChangeLog.txt
@@ -9,6 +9,16 @@
 #https://www.essential.exchange/blog/
 #
 
+#Version 2.24 13-Feb-2020
+#	Fixed several variable name typos
+#	General code cleanup
+#	Updated the following Exchange Schema Versions:
+#		"15312" = "Exchange 2013 CU7 through CU23"
+#		"15317" = "Exchange 2016 Preview and RTM"
+#		"15332" = "Exchange 2016 CU7 through CU15"
+#		"17000" = "Exchange 2019 RTM/CU1"
+#		"17001" = "Exchange 2019 CU2-CU4"
+
 #Version 2.23 17-Dec-2019
 #	Fix Swedish Table of Contents (Thanks to Johan Kallio)
 #		From 


### PR DESCRIPTION
#Version 2.24 13-Feb-2020
#	Fixed several variable name typos
#	General code cleanup
#	Updated the following Exchange Schema Versions:
#		"15312" = "Exchange 2013 CU7 through CU23"
#		"15317" = "Exchange 2016 Preview and RTM"
#		"15332" = "Exchange 2016 CU7 through CU15"
#		"17000" = "Exchange 2019 RTM/CU1"
#		"17001" = "Exchange 2019 CU2-CU4"