### PR TITLE
V2.26

### DIFF
--- a/ADDS_Inventory_V2.ps1
+++ b/ADDS_Inventory_V2.ps1
@@ -8,7 +8,7 @@
 	Creates a complete inventory of a Microsoft Active Directory Forest.
 .DESCRIPTION
 	Creates a complete inventory of a Microsoft Active Directory Forest using Microsoft 
-	PowerShell, Word, plain text or HTML.
+	PowerShell, Word, plain text, or HTML.
 	
 	Creates a Word or PDF document, text or HTML file named after the Active Directory Forest.
 	
@@ -852,9 +852,9 @@
 	No objects are output from this script.  This script creates a Word or PDF document.
 .NOTES
 	NAME: ADDS_Inventory_V2.ps1
-	VERSION: 2.25
+	VERSION: 2.26
 	AUTHOR: Carl Webster and Michael B. Smith
-	LASTEDIT: April 21, 2020
+	LASTEDIT: April 26, 2020
 #>
 
 
@@ -998,6 +998,13 @@ Param(
 #Version 1.0 released to the community on May 31, 2014
 #
 #Version 2.0 is based on version 1.20
+#
+#Version 2.26
+#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
+#	Add Receive Side Scaling setting to Function OutputNICItem
+#	Change Text output to use [System.Text.StringBuilder]
+#		Updated Functions Line and SaveAndCloseTextDocument
+#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
 #
 #Version 2.25 21-Apr-2020
 #	Remove the SMTP parameterset and manually verify the parameters
@@ -1326,7 +1333,15 @@ Else
 		Write-Verbose "$(Get-Date): Text is $($Text)"
 		Write-Verbose "$(Get-Date): HTML is $($HTML)"
 	}
-	Write-Error "Unable to determine output parameter.  Script cannot continue"
+	Write-Error "
+	`n`n
+	`t`t
+	Unable to determine output parameter.
+	`n`n
+	`t`t
+	Script cannot continue.
+	`n`n
+	"
 	Exit
 }
 
@@ -1364,7 +1379,13 @@ Switch ($Section)
 If($ValidSection -eq $False)
 {
 	$ErrorActionPreference = $SaveEAPreference
-	Write-Error -Message "`n`tThe Section parameter specified, $($Section), is an invalid Section option.`n`tValid options are:
+	Write-Error -Message "
+	`n`n
+	`t`t
+	The Section parameter specified, $($Section), is an invalid Section option.
+	`n`n
+	`t`t
+	Valid options are:
 	
 	`t`tForest
 	`t`tSites
@@ -1375,7 +1396,10 @@ If($ValidSection -eq $False)
 	`t`tMisc
 	`t`tAll
 	
-	`tScript cannot continue."
+	`t`t
+	Script cannot continue.
+	`n`n
+	"
 	Exit
 }
 
@@ -1394,14 +1418,30 @@ If($Folder -ne "")
 		Else
 		{
 			#it exists but it is a file not a folder
-			Write-Error "Folder $Folder is a file, not a folder.  Script cannot continue"
+			Write-Error "
+			`n`n
+			`t`t
+			Folder $Folder is a file, not a folder.
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			"
 			Exit
 		}
 	}
 	Else
 	{
 		#does not exist
-		Write-Error "Folder $Folder does not exist.  Script cannot continue"
+		Write-Error "
+		`n`n
+		`t`t
+		Folder $Folder does not exist.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		Exit
 	}
 }
@@ -1411,9 +1451,11 @@ If(![String]::IsNullOrEmpty($SmtpServer) -and [String]::IsNullOrEmpty($From) -an
 {
 	Write-Error "
 	`n`n
-	`tYou specified an SmtpServer but did not include a From or To email address.
+	`t`t
+	You specified an SmtpServer but did not include a From or To email address.
 	`n`n
-	`tScript cannot continue.
+	`t`t
+	Script cannot continue.
 	`n`n"
 	Exit
 }
@@ -1421,9 +1463,11 @@ If(![String]::IsNullOrEmpty($SmtpServer) -and [String]::IsNullOrEmpty($From) -an
 {
 	Write-Error "
 	`n`n
-	`tYou specified an SmtpServer and a To email address but did not include a From email address.
+	`t`t
+	You specified an SmtpServer and a To email address but did not include a From email address.
 	`n`n
-	`tScript cannot continue.
+	`t`t
+	Script cannot continue.
 	`n`n"
 	Exit
 }
@@ -1431,9 +1475,11 @@ If(![String]::IsNullOrEmpty($SmtpServer) -and [String]::IsNullOrEmpty($To) -and 
 {
 	Write-Error "
 	`n`n
-	`tYou specified an SmtpServer and a From email address but did not include a To email address.
+	`t`t
+	You specified an SmtpServer and a From email address but did not include a To email address.
 	`n`n
-	`tScript cannot continue.
+	`t`t
+	Script cannot continue.
 	`n`n"
 	Exit
 }
@@ -1441,9 +1487,11 @@ If(![String]::IsNullOrEmpty($From) -and ![String]::IsNullOrEmpty($To) -and [Stri
 {
 	Write-Error "
 	`n`n
-	`tYou specified From and To email addresses but did not include the SmtpServer.
+	`t`t
+	You specified From and To email addresses but did not include the SmtpServer.
 	`n`n
-	`tScript cannot continue.
+	`t`t
+	Script cannot continue.
 	`n`n"
 	Exit
 }
@@ -1451,9 +1499,11 @@ If(![String]::IsNullOrEmpty($From) -and [String]::IsNullOrEmpty($SmtpServer))
 {
 	Write-Error "
 	`n`n
-	`tYou specified a From email address but did not include the SmtpServer.
+	`t`t
+	You specified a From email address but did not include the SmtpServer.
 	`n`n
-	`tScript cannot continue.
+	`t`t
+	Script cannot continue.
 	`n`n"
 	Exit
 }
@@ -1461,9 +1511,11 @@ If(![String]::IsNullOrEmpty($To) -and [String]::IsNullOrEmpty($SmtpServer))
 {
 	Write-Error "
 	`n`n
-	`tYou specified a To email address but did not include the SmtpServer.
+	`t`t
+	You specified a To email address but did not include the SmtpServer.
 	`n`n
-	`tScript cannot continue.
+	`t`t
+	Script cannot continue.
 	`n`n"
 	Exit
 }
@@ -1580,7 +1632,7 @@ If($HTML)
 
 If($TEXT)
 {
-	$global:output = ""
+	[System.Text.StringBuilder] $global:Output = New-Object System.Text.StringBuilder( 16384 )
 }
 #endregion
 
@@ -2028,7 +2080,7 @@ Function GetComputerWMIInfo
 				
 				If($? -and $Null -ne $ThisNic)
 				{
-					OutputNicItem $Nic $ThisNic
+					OutputNicItem $Nic $ThisNic $RemoteComputerName
 				}
 				ElseIf(!$?)
 				{
@@ -2455,9 +2507,9 @@ Function OutputProcessorItem
 
 Function OutputNicItem
 {
-	Param([object]$Nic, [object]$ThisNic)
+	Param([object]$Nic, [object]$ThisNic, [string]$RemoteComputerName)
 	
-	$powerMgmt = Get-WmiObject MSPower_DeviceEnable -Namespace root\wmi | Where-Object {$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
+	$powerMgmt = Get-WmiObject -computername $RemoteComputerName MSPower_DeviceEnable -Namespace root\wmi | Where-Object{$_.InstanceName -match [regex]::Escape($ThisNic.PNPDeviceID)}
 
 	If($? -and $Null -ne $powerMgmt)
 	{
@@ -2476,28 +2528,50 @@ Function OutputNicItem
 	}
 	
 	$xAvailability = ""
-	Switch ($processor.availability)
+	Switch ($ThisNic.availability)
 	{
-		1	{$xAvailability = "Other"; Break}
-		2	{$xAvailability = "Unknown"; Break}
-		3	{$xAvailability = "Running or Full Power"; Break}
-		4	{$xAvailability = "Warning"; Break}
-		5	{$xAvailability = "In Test"; Break}
-		6	{$xAvailability = "Not Applicable"; Break}
-		7	{$xAvailability = "Power Off"; Break}
-		8	{$xAvailability = "Off Line"; Break}
-		9	{$xAvailability = "Off Duty"; Break}
-		10	{$xAvailability = "Degraded"; Break}
-		11	{$xAvailability = "Not Installed"; Break}
-		12	{$xAvailability = "Install Error"; Break}
-		13	{$xAvailability = "Power Save - Unknown"; Break}
-		14	{$xAvailability = "Power Save - Low Power Mode"; Break}
-		15	{$xAvailability = "Power Save - Standby"; Break}
-		16	{$xAvailability = "Power Cycle"; Break}
-		17	{$xAvailability = "Power Save - Warning"; Break}
+		1		{$xAvailability = "Other"; Break}
+		2		{$xAvailability = "Unknown"; Break}
+		3		{$xAvailability = "Running or Full Power"; Break}
+		4		{$xAvailability = "Warning"; Break}
+		5		{$xAvailability = "In Test"; Break}
+		6		{$xAvailability = "Not Applicable"; Break}
+		7		{$xAvailability = "Power Off"; Break}
+		8		{$xAvailability = "Off Line"; Break}
+		9		{$xAvailability = "Off Duty"; Break}
+		10		{$xAvailability = "Degraded"; Break}
+		11		{$xAvailability = "Not Installed"; Break}
+		12		{$xAvailability = "Install Error"; Break}
+		13		{$xAvailability = "Power Save - Unknown"; Break}
+		14		{$xAvailability = "Power Save - Low Power Mode"; Break}
+		15		{$xAvailability = "Power Save - Standby"; Break}
+		16		{$xAvailability = "Power Cycle"; Break}
+		17		{$xAvailability = "Power Save - Warning"; Break}
 		Default	{$xAvailability = "Unknown"; Break}
 	}
 
+	#attempt to get Receive Side Scaling setting
+	$RSSEnabled = "N/A"
+	Try
+	{
+		#https://ios.developreference.com/article/10085450/How+do+I+enable+VRSS+(Virtual+Receive+Side+Scaling)+for+a+Windows+VM+without+relying+on+Enable-NetAdapterRSS%3F
+		$RSSEnabled = (Get-WmiObject -ComputerName $RemoteComputerName MSFT_NetAdapterRssSettingData -Namespace "root\StandardCimV2" -ea 0).Enabled
+
+		If($RSSEnabled)
+		{
+			$RSSEnabled = "Enabled"
+		}
+		ELse
+		{
+			$RSSEnabled = "Disabled"
+		}
+	}
+	
+	Catch
+	{
+		$RSSEnabled = "Not available on $Script:RunningOS"
+	}
+	
 	$xIPAddress = New-Object System.Collections.ArrayList
 	ForEach($IPAddress in $Nic.ipaddress)
 	{
@@ -2574,6 +2648,7 @@ Function OutputNicItem
 		}
 		$NicInformation.Add(@{ Data = "Availability"; Value = $xAvailability; }) > $Null
 		$NicInformation.Add(@{ Data = "Allow the computer to turn off this device to save power"; Value = $PowerSaving; }) > $Null
+		$NicInformation.Add(@{ Data = "Receive Side Scaling"; Value = $RSSEnabled; }) > $Null
 		$NicInformation.Add(@{ Data = "Physical Address"; Value = $Nic.macaddress; }) > $Null
 		If($xIPAddress.Count -gt 1)
 		{
@@ -2685,6 +2760,7 @@ Function OutputNicItem
 		Line 2 "Availability`t`t: " $xAvailability
 		Line 2 "Allow computer to turn "
 		Line 2 "off device to save power: " $PowerSaving
+		Line 2 "Receive Side Scaling`t: " $RSSEnabled
 		Line 2 "Physical Address`t: " $nic.macaddress
 		Line 2 "IP Address`t`t: " $xIPAddress[0]
 		$cnt = -1
@@ -2786,6 +2862,7 @@ Function OutputNicItem
 		$rowdata += @(,('Availability',($htmlsilver -bor $htmlbold),$xAvailability,$htmlwhite))
 		$rowdata += @(,('Allow the computer to turn off this device to save power',($htmlsilver -bor $htmlbold),$PowerSaving,$htmlwhite))
 		$rowdata += @(,('Physical Address',($htmlsilver -bor $htmlbold),$Nic.macaddress,$htmlwhite))
+		$rowdata += @(,('Receive Side Scaling',($htmlsilver -bor $htmlbold),$RSSEnabled,$htmlwhite))
 		$rowdata += @(,('IP Address',($htmlsilver -bor $htmlbold),$xIPAddress[0],$htmlwhite))
 		$cnt = -1
 		ForEach($tmp in $xIPAddress)
@@ -3699,7 +3776,18 @@ Function SetupWord
 	{
 		Write-Warning "The Word object could not be created.  You may need to repair your Word installation."
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tThe Word object could not be created.  You may need to repair your Word installation.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		The Word object could not be created.
+		`n`n
+		`t`t
+		You may need to repair your Word installation.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		Exit
 	}
 
@@ -3716,7 +3804,15 @@ Function SetupWord
 	If(!($Script:WordLanguageValue -gt -1))
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tUnable to determine the Word language value.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		Unable to determine the Word language value.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 	Write-Verbose "$(Get-Date): Word language value is $($Script:WordLanguageValue)"
@@ -3741,13 +3837,45 @@ Function SetupWord
 	ElseIf($Script:WordVersion -eq $wdWord2007)
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tMicrosoft Word 2007 is no longer supported.`n`n`t`tScript will end.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		Microsoft Word 2007 is no longer supported.
+		`n`n
+		`t`t
+		Script will end.
+		`n`n
+		"
 		AbortScript
+	}
+	ElseIf($Script:WordVersion -eq 0)
+	{
+		Write-Error "
+		`n`n
+		`t`t
+		The Word Version is 0. You should run a full online repair of your Office installation.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
+		Exit
 	}
 	Else
 	{
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tYou are running an untested or unsupported version of Microsoft Word.`n`n`t`tScript will end.`n`n`t`tPlease send info on your version of Word to webster@carlwebster.com`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		You are running an untested or unsupported version of Microsoft Word.
+		`n`n
+		`t`t
+		Script will end.
+		`n`n
+		`t`t
+		Please send info on your version of Word to webster@carlwebster.com
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3889,7 +4017,15 @@ Function SetupWord
 		$ErrorActionPreference = $SaveEAPreference
 		Write-Verbose "$(Get-Date): Word language value $($Script:WordLanguageValue)"
 		Write-Verbose "$(Get-Date): Culture code $($Script:WordCultureCode)"
-		Write-Error "`n`n`t`tFor $($Script:WordProduct), $($CoverPage) is not a valid Cover Page option.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		For $($Script:WordProduct), $($CoverPage) is not a valid Cover Page option.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3952,7 +4088,15 @@ Function SetupWord
 	{
 		Write-Verbose "$(Get-Date): "
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tAn empty Word document could not be created.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		An empty Word document could not be created.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -3961,7 +4105,15 @@ Function SetupWord
 	{
 		Write-Verbose "$(Get-Date): "
 		$ErrorActionPreference = $SaveEAPreference
-		Write-Error "`n`n`t`tAn unknown error happened selecting the entire Word document for default formatting options.`n`n`t`tScript cannot continue.`n`n"
+		Write-Error "
+		`n`n
+		`t`t
+		An unknown error happened selecting the entire Word document for default formatting options.
+		`n`n
+		`t`t
+		Script cannot continue.
+		`n`n
+		"
 		AbortScript
 	}
 
@@ -4171,21 +4323,35 @@ Function Get-RegistryValue
 #region word, text and html line output functions
 Function line
 #function created by Michael B. Smith, Exchange MVP
-#@essentialexchange on Twitter
-#http://TheEssentialExchange.com
+#@essentialexch on Twitter
+#https://essential.exchange/blog
 #for creating the formatted text report
 #created March 2011
 #updated March 2014
+# updated March 2019 to use StringBuilder (about 100 times more efficient than simple strings)
 {
-	Param( [int]$tabs = 0, [string]$name = '', [string]$value = '', [string]$newline = "`r`n", [switch]$nonewline )
-	While( $tabs -gt 0 ) { $Global:Output += "`t"; $tabs--; }
+	Param
+	(
+		[Int]    $tabs = 0, 
+		[String] $name = '', 
+		[String] $value = '', 
+		[String] $newline = [System.Environment]::NewLine, 
+		[Switch] $nonewline
+	)
+
+	while( $tabs -gt 0 )
+	{
+		$null = $global:Output.Append( "`t" )
+		$tabs--
+	}
+
 	If( $nonewline )
 	{
-		$Global:Output += $name + $value
+		$null = $global:Output.Append( $name + $value )
 	}
 	Else
 	{
-		$Global:Output += $name + $value + $newline
+		$null = $global:Output.AppendLine( $name + $value )
 	}
 }
 	
@@ -6415,7 +6581,7 @@ Function SaveandCloseTextDocument
 		$Script:FileName1 += "_$(Get-Date -f yyyy-MM-dd_HHmm).txt"
 	}
 
-	Write-Output $Global:Output | Out-File $Script:Filename1 4>$Null
+	Write-Output $global:Output.ToString() | Out-File $Script:Filename1 4>$Null
 }
 
 Function SaveandCloseHTMLDocument
@@ -6691,7 +6857,15 @@ Function ProcessScriptSetup
 				If(!$?)
 				{
 					$ErrorActionPreference = $SaveEAPreference
-					Write-Error "`n`n`t`t$ComputerName is not a domain controller for $ADForest.`n`t`tScript cannot continue.`n`n"
+					Write-Error "
+					`n`n
+					`t`t
+					$ComputerName is not a domain controller for $ADForest.
+					`n`n
+					`t`t
+					Script cannot continue.
+					`n`n
+					"
 					Exit
 				}
 				Else
@@ -6710,7 +6884,15 @@ Function ProcessScriptSetup
 		{
 			Write-Verbose "$(Get-Date): Computer $ComputerName is offline"
 			$ErrorActionPreference = $SaveEAPreference
-			Write-Error "`n`n`t`tComputer $ComputerName is offline.`nScript cannot continue.`n`n"
+			Write-Error "
+			`n`n
+			`t`t
+			Computer $ComputerName is offline.
+			`n`n
+			`t`t
+			Script cannot continue.
+			`n`n
+			"
 			Exit
 		}
 	}
@@ -6726,7 +6908,15 @@ Function ProcessScriptSetup
 			If(!$?)
 			{
 				$ErrorActionPreference = $SaveEAPreference
-				Write-Error "`n`n`t`tCould not find a forest identified by: $ADForest.`nScript cannot continue.`n`n"
+				Write-Error "
+				`n`n
+				`t`t
+				Could not find a forest identified by: $ADForest.
+				`n`n
+				`t`t
+				Script cannot continue.
+				`n`n
+				"
 				Exit
 			}
 		}
@@ -6737,7 +6927,18 @@ Function ProcessScriptSetup
 			If(!$?)
 			{
 				$ErrorActionPreference = $SaveEAPreference
-				Write-Error "`n`n`t`tCould not find a forest with the name of $ADForest.`n`n`t`tScript cannot continue.`n`n`t`tIs $ComputerName running Active Directory Web Services?"
+				Write-Error "
+				`n`n
+				`t`t
+				Could not find a forest with the name of $ADForest.
+				`n`n
+				`t`t
+				Script cannot continue.
+				`n`n
+				`t`t
+				Is $ComputerName running Active Directory Web Services?
+				`n`n
+				"
 				Exit
 			}
 		}
@@ -6756,7 +6957,15 @@ Function ProcessScriptSetup
 			If(!$?)
 			{
 				$ErrorActionPreference = $SaveEAPreference
-				Write-Error "`n`n`t`tCould not find a domain identified by: $ADDomain.`nScript cannot continue.`n`n"
+				Write-Error "
+				`n`n
+				`t`t
+				Could not find a domain identified by: $ADDomain.
+				`n`n
+				`t`t
+				Script cannot continue.
+				`n`n
+				"
 				Exit
 			}
 		}
@@ -6767,7 +6976,18 @@ Function ProcessScriptSetup
 			If(!$?)
 			{
 				$ErrorActionPreference = $SaveEAPreference
-				Write-Error "`n`n`t`tCould not find a domain with the name of $ADDomain.`n`n`t`tScript cannot continue.`n`n`t`tIs $ComputerName running Active Directory Web Services?"
+				Write-Error "
+				`n`n
+				`t`t
+				Could not find a domain with the name of $ADDomain.
+				`n`n
+				`t`t
+				Script cannot continue.
+				`n`n
+				`t`t
+				Is $ComputerName running Active Directory Web Services?
+				`n`n
+				"
 				Exit
 			}
 		}
@@ -6786,7 +7006,15 @@ Function ProcessScriptSetup
 			If(!$?)
 			{
 				$ErrorActionPreference = $SaveEAPreference
-				Write-Error "`n`n`t`tCould not find a forest identified by: $tmp.`nScript cannot continue.`n`n"
+				Write-Error "
+				`n`n
+				`t`t
+				Could not find a forest identified by: $tmp.
+				`n`n
+				`t`t
+				Script cannot continue.
+				`n`n
+				"
 				Exit
 			}
 		}
@@ -6797,7 +7025,18 @@ Function ProcessScriptSetup
 			If(!$?)
 			{
 				$ErrorActionPreference = $SaveEAPreference
-				Write-Error "`n`n`t`tCould not find a forest with the name of $tmp.`n`n`t`tScript cannot continue.`n`n`t`tIs $ComputerName running Active Directory Web Services?"
+				Write-Error "
+				`n`n
+				`t`t
+				Could not find a forest with the name of $tmp.
+				`n`n
+				`t`t
+				Script cannot continue.
+				`n`n
+				`t`t
+				Is $ComputerName running Active Directory Web Services?
+				`n`n
+				"
 				Exit
 			}
 		}

--- a/ADDS_Inventory_V2_ReadMe.rtf
+++ b/ADDS_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -88,13 +88,13 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 {\listoverride\listid319386001\listoverridecount0\ls3}{\listoverride\listid1724937716\listoverridecount0\ls4}{\listoverride\listid1818835589\listoverridecount9{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}
 {\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
 \levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid2638156\rsid2710199\rsid2974686\rsid3342358\rsid3477011
-\rsid3828116\rsid3830441\rsid4281248\rsid4338650\rsid4467197\rsid4665378\rsid4945864\rsid5720771\rsid5767175\rsid5849890\rsid6031750\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7681868\rsid7695940\rsid8013811\rsid8793422\rsid9119488\rsid9243658
-\rsid9252303\rsid9512169\rsid9838801\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid11865833\rsid12197314\rsid12343757\rsid12792789\rsid12848963\rsid12856395\rsid12916989
-\rsid13005600\rsid13133162\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0\msmallFrac0
-\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo4\dy22\hr6\min1}{\version50}{\edmins553}{\nofpages24}{\nofwords7588}{\nofchars43257}
-{\nofcharsws50744}{\vern127}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
+\rsid3828116\rsid3830441\rsid4281248\rsid4338650\rsid4467197\rsid4665378\rsid4945864\rsid5720771\rsid5767175\rsid5849890\rsid6031750\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7488809\rsid7681868\rsid7695940\rsid8013811\rsid8793422\rsid9119488
+\rsid9243658\rsid9252303\rsid9512169\rsid9838801\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid11865833\rsid12197314\rsid12343757\rsid12792789\rsid12848963\rsid12856395
+\rsid12916989\rsid13005600\rsid13133162\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
+\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo4\dy26\hr14\min23}{\version51}{\edmins554}{\nofpages24}{\nofwords7588}
+{\nofchars43258}{\nofcharsws50745}{\vern127}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
-\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale100\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
+\dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
 {\*\docvar {__Grammarly_42___1}{H4sIAAAAAAAEAKtWcslP9kxRslIyNDY0NTMyNzQ1tzQxNzCxsDRW0lEKTi0uzszPAykwrwUApnIXnSwAAAA=}}\ltrpar \sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\*\pnseclvl1\pnucrm\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl2
 \pnucltr\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl3\pndec\pnstart1\pnindent720\pnhang {\pntxta .}}{\*\pnseclvl4\pnlcltr\pnstart1\pnindent720\pnhang {\pntxta )}}{\*\pnseclvl5\pndec\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl6
 \pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl7\pnlcrm\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl8\pnlcltr\pnstart1\pnindent720\pnhang {\pntxtb (}{\pntxta )}}{\*\pnseclvl9\pnlcrm\pnstart1\pnindent720\pnhang 
@@ -215,7 +215,7 @@ lowing languages:
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2974686 \hich\af31506\dbch\af31505\loch\f31506 Disabled users
 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Unknown users
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Locked out users
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Locked\hich\af31506\dbch\af31505\loch\f31506  out users
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 All users with password expired
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686\charrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}\pard \ltrpar
 \ql \fi-360\li2160\ri0\nowidctlpar\wrapdefault\faauto\ls4\ilvl2\rin0\lin2160\itap0\pararsid2974686 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2974686\charrsid2974686 \hich\af37\dbch\af31505\loch\f37 All users whose password never expires}{
@@ -226,8 +226,8 @@ lowing languages:
 \hich\af37\dbch\af31505\loch\f37 All users who cannot change password}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2974686\charrsid2974686 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686\charrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2974686\charrsid2974686 
 \hich\af37\dbch\af31505\loch\f37 All users with SID History}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2974686\charrsid2974686 
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2974686 \hich\af37\dbch\af31505\loch\f37 All users wit
-\hich\af37\dbch\af31505\loch\f37 h Homedrive set in ADUC}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2974686\charrsid2974686 
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2974686 \hich\af37\dbch\af31505\loch\f37 
+All users with Homedrive set in ADUC}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2974686\charrsid2974686 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2974686 \hich\af37\dbch\af31505\loch\f37 
 All users whose Primary Group is not Domain Users}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2974686\charrsid2974686 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2974686 \hich\af37\dbch\af31505\loch\f37 
@@ -273,35 +273,36 @@ At least one Windows 7 SP1 or later computer with the Remote Server Administrati
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 
  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=7887" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9200000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff000060000030000000003a}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff000060000030000000003a00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d0146d0e00010000980000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administratio\hich\af37\dbch\af31505\loch\f37 n Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \f37\fs22\insrsid11602030 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d0146d0e0001000098000066}}}{\fldrslt {\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administratio\hich\af37\dbch\af31505\loch\f37 n Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a64006d0000006300c800f6}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
-\ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a64006d0000006300c800f672}}}{\fldrslt {\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
 \nowidctlpar\wrapdefault\faauto\ls2\ilvl1\rin0\lin1440\itap0\pararsid13858952\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 RSAT for Windows 10 is available here, }
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c0000000000360000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
-\cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c000000000036000002}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+\ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
+
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \par \hich\af37\dbch\af31505\loch\f37 This script was developed using Windows Server 20}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 12}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-\hich\af37\dbch\af31505\loch\f37  R2 domain controllers and PowerShell Version }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 5}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-\hich\af37\dbch\af31505\loch\f37 .0. The script was run on several Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 10}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
-\hich\af37\dbch\af31505\loch\f37  computers with RSAT}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37  and }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 
-Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid5849890 
-\hich\af37\dbch\af31505\loch\f37  The script now requires PowerShell V3 or later.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
+\hich\af37\dbch\af31505\loch\f37  R2\hich\af37\dbch\af31505\loch\f37  domain controllers and PowerShell Version }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 5}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37 .0. The script was run on several Windows }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 10}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid10290913 \hich\af37\dbch\af31505\loch\f37  computers with RSAT}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37  and }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
+\hich\af37\dbch\af31505\loch\f37 Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af37\dbch\af31505\loch\f37 3}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 .}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
+\f37\fs22\insrsid5849890 \hich\af37\dbch\af31505\loch\f37  The script now requires PowerShell V3 or later.}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
 \par }\pard\plain \ltrpar\s2\ql \li0\ri0\sb200\sl276\slmult1\keep\keepn\nowidctlpar\wrapdefault\faauto\outlinelevel1\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 
 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {\rtlch\fcs1 \ab\af43\afs26 \ltrch\fcs0 \b\fs26\cf22\insrsid11488686 \hich\af43\dbch\af31505\loch\f43 Script Usage
 \par }\pard\plain \ltrpar\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid11488686 \rtlch\fcs1 \af0\afs24\alang1025 \ltrch\fcs0 \fs24\lang1033\langfe1033\loch\af43\hich\af43\dbch\af31505\cgrid\langnp1033\langfenp1033 {
@@ -311,7 +312,7 @@ Word 201}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13725463 \hich\af
 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 Save the script as }{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 ADDS}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 
 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 _Inventor}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 y}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid2638156 
 \hich\af37\dbch\af31505\loch\f37 _V2}{\rtlch\fcs1 \ai\af37\afs22 \ltrch\fcs0 \i\f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 .ps1 }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 
-\hich\af37\dbch\af31505\loch\f37 in your PowerShell scripts folder.
+\hich\af37\dbch\af31505\loch\f37 in \hich\af37\dbch\af31505\loch\f37 your PowerShell scripts folder.
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 2.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, change to your PowerShell scripts}{
 \rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13133162 \hich\af37\dbch\af31505\loch\f37  folder}{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 .
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11488686\charrsid13987238 \hich\af37\dbch\af31505\loch\f37 3.\tab}\hich\af37\dbch\af31505\loch\f37 From the PowerShell prompt, type in:
@@ -429,7 +430,7 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 DESCRIPTION
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest using Microsoft
-\par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text or HTML.
+\par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7488809 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2  or HTML.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text or HTML file named after\hich\af2\dbch\af31505\loch\f2  the Active Directory Forest.
 \par 
@@ -455,50 +456,50 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     You do NOT have to run this script on a domain controller. This script was developed
 \par \hich\af2\dbch\af31505\loch\f2     and run from a Windows 10 VM.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     While most of the script can be run with a \hich\af2\dbch\af31505\loch\f2 non-admin account, there are some features
+\par \hich\af2\dbch\af31505\loch\f2     While most of the script can be run with a non-admin account, there are some features
 \par \hich\af2\dbch\af31505\loch\f2     that will not or may not work without domain admin or enterprise admin rights.
-\par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters require domain admin privileges.
+\par \hich\af2\dbch\af31505\loch\f2     The Hardware and Services parameters requir\hich\af2\dbch\af31505\loch\f2 e domain admin privileges.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Version 2.0 of the script adds gathering informatio\hich\af2\dbch\af31505\loch\f2 n on Time Server and AD database,
+\par \hich\af2\dbch\af31505\loch\f2     Version 2.0 of the script adds gathering information on Time Server and AD database,
 \par \hich\af2\dbch\af31505\loch\f2     log file, and SYSVOL locations. Those require access to the registry on each domain
-\par \hich\af2\dbch\af31505\loch\f2     controller, which means the script should now always be run from an elevated PowerShell
-\par \hich\af2\dbch\af31505\loch\f2     session with an account with a minimum\hich\af2\dbch\af31505\loch\f2  of domain admin rights.
+\par \hich\af2\dbch\af31505\loch\f2     controller, which means the script should now a\hich\af2\dbch\af31505\loch\f2 lways be run from an elevated PowerShell
+\par \hich\af2\dbch\af31505\loch\f2     session with an account with a minimum of domain admin rights.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Running the script in a forest with multiple domains requires Enterprise Admin rights.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if the user running the script doesn't have
-\par \hich\af2\dbch\af31505\loch\f2     the necessary permissions on all user objec\hich\af2\dbch\af31505\loch\f2 ts.  In that case, there may be user accounts
+\par \hich\af2\dbch\af31505\loch\f2     The count of all users may not be accurate if the u\hich\af2\dbch\af31505\loch\f2 ser running the script doesn't have
+\par \hich\af2\dbch\af31505\loch\f2     the necessary permissions on all user objects.  In that case, there may be user accounts
 \par \hich\af2\dbch\af31505\loch\f2     classified as "unknown".
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To run the script from a workstation, RSAT is required.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)
-\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft\hich\af2\dbch\af31505\loch\f2 .com/en-us/download/details.aspx?id=7887" 
-}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Too\hich\af2\dbch\af31505\loch\f2 ls for Windows 7 with Service Pack 1 (SP1)
+\par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=7887" }{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9200000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
+65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004a}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=7887}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
-\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=28972}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab00030080}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
+\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details\hich\af2\dbch\af31505\loch\f2 .aspx?id=28972}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006e}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=39296}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 
  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
-\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/deta\hich\af2\dbch\af31505\loch\f2 ils.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030065}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
+\hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/det\hich\af2\dbch\af31505\loch\f2 ails.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 PARAMETERS
@@ -507,20 +508,20 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The following Cover Pages have an Address field:
 \par \hich\af2\dbch\af31505\loch\f2                 Banded (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Contrast (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2               Contrast (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Exposure (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 Filigree (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016)
-\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     Tiles (Word 2010)
+\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      Tiles (Word 2010)
 \par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CA.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?     \hich\af2\dbch\af31505\loch\f2                named
+\par \hich\af2\dbch\af31505\loch\f2         Position?    \hich\af2\dbch\af31505\loch\f2                 named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -612,31 +613,31 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fi\hich\af2\dbch\af31505\loch\f2 t; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resiz\hich\af2\dbch\af31505\loch\f2 ed or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Newsprint\hich\af2\dbch\af31505\loch\f2  (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or font cha\hich\af2\dbch\af31505\loch\f2 nged to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Wor\hich\af2\dbch\af31505\loch\f2 d 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) \hich\af2\dbch\af31505\loch\f2 (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Sl\hich\af2\dbch\af31505\loch\f2 ice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works\hich\af2\dbch\af31505\loch\f2 )
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Wor\hich\af2\dbch\af31505\loch\f2 ks)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parame\hich\af2\dbch\af31505\loch\f2 ters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -645,26 +646,26 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2         Userna\hich\af2\dbch\af31505\loch\f2 me to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid wi\hich\af2\dbch\af31505\loch\f2 th the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    fa\hich\af2\dbch\af31505\loch\f2 lse
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters\hich\af2\dbch\af31505\loch\f2 ?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .htm\hich\af2\dbch\af31505\loch\f2 l extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value       \hich\af2\dbch\af31505\loch\f2          False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard\hich\af2\dbch\af31505\loch\f2  characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
@@ -674,27 +675,27 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter require\hich\af2\dbch\af31505\loch\f2 s Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?      \hich\af2\dbch\af31505\loch\f2               false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?  \hich\af2\dbch\af31505\loch\f2      false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text \hich\af2\dbch\af31505\loch\f2 file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -702,26 +703,26 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         June \hich\af2\dbch\af31505\loch\f2 1, 2020 at 6PM is 2020-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
-\par \hich\af2\dbch\af31505\loch\f2         This p\hich\af2\dbch\af31505\loch\f2 arameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Defa\hich\af2\dbch\af31505\loch\f2 ult value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -A\hich\af2\dbch\af31505\loch\f2 DForest <String>
+\par \hich\af2\dbch\af31505\loch\f2     -ADForest <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory forest object by providing one of the following
 \par \hich\af2\dbch\af31505\loch\f2         attribute values.
-\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the attribute.
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      The identifier in parentheses is the LDAP display name for the attribute.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Fully qualified domain name
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         Example: labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par \hich\af2\dbch\af31505\loch\f2                 Example: 599c3d2e-e61e-4d20-7b77-030d99495e19
-\par \hich\af2\dbch\af31505\loch\f2         DNS host name
+\par \hich\af2\dbch\af31505\loch\f2         DNS\hich\af2\dbch\af31505\loch\f2  host name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         NetBIOS name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain
@@ -732,14 +733,14 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:US\hich\af2\dbch\af31505\loch\f2 ERDNSDOMAIN
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?   \hich\af2\dbch\af31505\loch\f2     false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in paren\hich\af2\dbch\af31505\loch\f2 theses is the LDAP display name for the
-\par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the domain.
+\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in parentheses is the LDAP display name for the
+\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    attribute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
 \par 
@@ -747,9 +748,9 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Exam\hich\af2\dbch\af31505\loch\f2 ple: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
+\par \hich\af2\dbch\af31505\loch\f2         Example: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Security Identifier (objectSid)
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Security Identifier (objectSid)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Example: S-1-5-21-3643273344-1505409314-3732760578
 \par 
@@ -764,51 +765,51 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies which domain controller to use to run the script against.
-\par \hich\af2\dbch\af31505\loch\f2         If ADForest is a tr\hich\af2\dbch\af31505\loch\f2 usted forest, then ComputerName is required to detect the
+\par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName is required to detect the
 \par \hich\af2\dbch\af31505\loch\f2         existence of ADForest.
-\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and use\hich\af2\dbch\af31505\loch\f2 d.
+\par \hich\af2\dbch\af31505\loch\f2         ComputerN\hich\af2\dbch\af31505\loch\f2 ame can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
-\par \hich\af2\dbch\af31505\loch\f2         computer name.
+\par \hich\af2\dbch\af31505\loch\f2         compute\hich\af2\dbch\af31505\loch\f2 r name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ServerName.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DCDNSInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather, for each domain controller, the IP Address, and each DNS server
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather, for each domain controller, the IP Address, and eac\hich\af2\dbch\af31505\loch\f2 h DNS server
 \par \hich\af2\dbch\af31505\loch\f2         configured.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardwa\hich\af2\dbch\af31505\loch\f2 re information (i.e. Domain
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add an extra section to the report.
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter w\hich\af2\dbch\af31505\loch\f2 ill add an extra section to the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                   \hich\af2\dbch\af31505\loch\f2  false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -GPOInheritance [<SwitchParameter>]
@@ -986,19 +987,19 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
+\par \hich\af2\dbch\af31505\loch\f2         The\hich\af2\dbch\af31505\loch\f2  text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                Fal\hich\af2\dbch\af31505\loch\f2 se
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ScriptInfo [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Outputs information about the script to a text file.
-\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the scr\hich\af2\dbch\af31505\loch\f2 ipt is run.
+\par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of SI.
@@ -1006,7 +1007,7 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline\hich\af2\dbch\af31505\loch\f2  input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?    \hich\af2\dbch\af31505\loch\f2    false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Log [<SwitchParameter>]
@@ -1014,7 +1015,7 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value     \hich\af2\dbch\af31505\loch\f2            False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                \hich\af2\dbch\af31505\loch\f2 False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
@@ -1022,10 +1023,10 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         This cmdlet supports the common parameters: Verbose, Debug,
 \par \hich\af2\dbch\af31505\loch\f2         ErrorAction, ErrorVariable, WarningAction, WarningVariable,
 \par \hich\af2\dbch\af31505\loch\f2         OutBuffer, PipelineVariable, and OutVariable. For more information, see
-\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/g\hich\af2\dbch\af31505\loch\f2 o.microsoft.com/fwlink/?LinkID=113216).
+\par \hich\af2\dbch\af31505\loch\f2         about_CommonParameters (https:/go.microsoft.com/fwlink/?LinkID=113216).
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 INPUTS
-\par \hich\af2\dbch\af31505\loch\f2     None.  You cannot pipe objects to this script.
+\par \hich\af2\dbch\af31505\loch\f2     None.  You canno\hich\af2\dbch\af31505\loch\f2 t pipe objects to this script.
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2 OUTPUTS
@@ -1035,31 +1036,31 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2 NOTES
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         NAME: ADDS_Inventory_V2.ps1
-\par \hich\af2\dbch\af31505\loch\f2         VERSI\hich\af2\dbch\af31505\loch\f2 ON: 2.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 5}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
-
+\par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7488809 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
-\par \hich\af2\dbch\af31505\loch\f2         LASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 April }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13005600 \hich\af2\dbch\af31505\loch\f2 21}{
-\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 , 2020}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
+\par \hich\af2\dbch\af31505\loch\f2         L\hich\af2\dbch\af31505\loch\f2 ASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 April }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13005600 
+\hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7488809 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 , 2020}{\rtlch\fcs1 \af2\afs18 
+\ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\\hich\af2\dbch\af31505\loch\f2 CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Nam\hich\af2\dbch\af31505\loch\f2 e.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for\hich\af2\dbch\af31505\loch\f2  the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller th\hich\af2\dbch\af31505\loch\f2 at is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 value for ComputerName.
 \par 
 \par 
 \par 
@@ -1068,19 +1069,19 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest company.tld
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default val\hich\af2\dbch\af31505\loch\f2 ues.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\User\hich\af2\dbch\af31505\loch\f2 Info\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Compan\hich\af2\dbch\af31505\loch\f2 y Name.
+\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog\hich\af2\dbch\af31505\loch\f2  server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
@@ -1091,18 +1092,18 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADDomain child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT\hich\af2\dbch\af31505\loch\f2 _USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\\hich\af2\dbch\af31505\loch\f2 Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline \hich\af2\dbch\af31505\loch\f2 for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     child.company.tld for the AD Domain.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Com\hich\af2\dbch\af31505\loch\f2 puterName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server\hich\af2\dbch\af31505\loch\f2  and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par 
@@ -1114,22 +1115,22 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain child.company.tld
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\\hich\af2\dbch\af31505\loch\f2 Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
+\par \hich\af2\dbch\af31505\loch\f2     $\hich\af2\dbch\af31505\loch\f2 env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     A\hich\af2\dbch\af31505\loch\f2 dministrator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Because both ADForest and ADDomain are specified, ADDomain wins and child.company.tld
-\par \hich\af2\dbch\af31505\loch\f2     is used for AD Domain.
+\par \hich\af2\dbch\af31505\loch\f2     is used for AD \hich\af2\dbch\af31505\loch\f2 Domain.
 \par \hich\af2\dbch\af31505\loch\f2     ADForest is set to the value of ADDomain.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAI\hich\af2\dbch\af31505\loch\f2 N, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
 \par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
-\par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     value for ComputerNam\hich\af2\dbch\af31505\loch\f2 e.
 \par 
 \par 
 \par 
@@ -1139,14 +1140,14 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest company.tld -ComputerName DC01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Comp\hich\af2\dbch\af31505\loch\f2 anyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the\hich\af2\dbch\af31505\loch\f2  User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administ\hich\af2\dbch\af31505\loch\f2 rator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     company.tld for the AD Forest
 \par \hich\af2\dbch\af31505\loch\f2     The script will be run remotely on the DC01 domain controller.
 \par 
@@ -1155,12 +1156,12 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 6 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -PDF -ADForest corp.carlwe\hich\af2\dbch\af31505\loch\f2 bster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -PDF -ADFores\hich\af2\dbch\af31505\loch\f2 t corp.carlwebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl \hich\af2\dbch\af31505\loch\f2 Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\C\hich\af2\dbch\af31505\loch\f2 ompany="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
@@ -1175,19 +1176,19 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 7 --------------------------
+\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2  -------------------------- EXAMPLE 7 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -Text -ADForest corp.carlwebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a formatted text file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyNa\hich\af2\dbch\af31505\loch\f2 me="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwa\hich\af2\dbch\af31505\loch\f2 re\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administrator for the Use\hich\af2\dbch\af31505\loch\f2 r Name.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cov\hich\af2\dbch\af31505\loch\f2 er Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
@@ -1580,19 +1581,19 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300d0}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
 \par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The s\hich\af2\dbch\af31505\loch\f2 cript will generate an anonymous secure password for the anonymous@domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     The script will generate an anonymous secure password for the anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     account.
 \par 
 \par 
@@ -1601,7 +1602,7 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer labaddomain-com.mail.protection\hich\af2\dbch\af31505\loch\f2 .outlook.com
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -SmtpServer labaddomain-com.mail.protection.outlook.com
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL
 \par \hich\af2\dbch\af31505\loch\f2     -From SomeEmailAddress@labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroupDL@labaddomain.com
@@ -1612,18 +1613,18 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 soft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab000300}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-applicat\hich\af2\dbch\af31505\loch\f2 
-ion-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030031}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}
+}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
+\par \hich\af2\dbch\af31505\loch\f2     This \hich\af2\dbch\af31505\loch\f2 uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
-\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending\hich\af2\dbch\af31505\loch\f2  to ITGroupDL@labaddomain.com.
+\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script\hich\af2\dbch\af31505\loch\f2  will use the default SMTP port 25 and will use SSL.
 \par 
 \par 
 \par 
@@ -1632,9 +1633,9 @@ ion-to-send-email-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.office365.com
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 -SmtpPort 587
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL
-\par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -From Webster@Ca\hich\af2\dbch\af31505\loch\f2 rlWebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
@@ -1787,8 +1788,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e500000000000000000000000080b3
-d25a9518d601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000c0ff
+ee20001cd601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_Inventory_V2_ReadMe.rtf
+++ b/ADDS_Inventory_V2_ReadMe.rtf
@@ -1,7 +1,7 @@
 {\rtf1\adeflang1025\ansi\ansicpg1252\uc1\adeff0\deff0\stshfdbch31505\stshfloch31506\stshfhich31506\stshfbi0\deflang1033\deflangfe1033\themelang1033\themelangfe0\themelangcs0{\fonttbl{\f0\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f2\fbidi \fmodern\fcharset0\fprq1{\*\panose 02070309020205020404}Courier New;}
 {\f3\fbidi \froman\fcharset2\fprq2{\*\panose 05050102010706020507}Symbol;}{\f10\fbidi \fnil\fcharset2\fprq2{\*\panose 05000000000000000000}Wingdings;}{\f34\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria Math;}
-{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
-{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 00000000000000000000}Cambria;}
+{\f37\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}{\f43\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}{\flomajor\f31500\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
+{\fdbmajor\f31501\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhimajor\f31502\fbidi \froman\fcharset0\fprq2{\*\panose 02040503050406030204}Cambria;}
 {\fbimajor\f31503\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\flominor\f31504\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}
 {\fdbminor\f31505\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\fhiminor\f31506\fbidi \fswiss\fcharset0\fprq2{\*\panose 020f0502020204030204}Calibri;}
 {\fbiminor\f31507\fbidi \froman\fcharset0\fprq2{\*\panose 02020603050405020304}Times New Roman;}{\f44\fbidi \froman\fcharset238\fprq2 Times New Roman CE;}{\f45\fbidi \froman\fcharset204\fprq2 Times New Roman Cyr;}
@@ -89,9 +89,9 @@ Normal Table;}{\*\cs15 \additive \rtlch\fcs1 \ab\af0\afs32 \ltrch\fcs0 \b\fs32\k
 {\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}{\lfolevel\listoverridestartat
 \levelstartat1}{\lfolevel\listoverridestartat\levelstartat1}\ls5}}{\*\pgptbl {\pgp\ipgp0\itap0\li0\ri0\sb0\sa0}}{\*\rsidtbl \rsid407474\rsid667579\rsid741398\rsid854968\rsid880017\rsid1520287\rsid2638156\rsid2710199\rsid2974686\rsid3342358\rsid3477011
 \rsid3828116\rsid3830441\rsid4281248\rsid4338650\rsid4467197\rsid4665378\rsid4945864\rsid5720771\rsid5767175\rsid5849890\rsid6031750\rsid6095241\rsid6508857\rsid6508924\rsid6626993\rsid7488809\rsid7681868\rsid7695940\rsid8013811\rsid8793422\rsid9119488
-\rsid9243658\rsid9252303\rsid9512169\rsid9838801\rsid10101060\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid11865833\rsid12197314\rsid12343757\rsid12792789\rsid12848963\rsid12856395
-\rsid12916989\rsid13005600\rsid13133162\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0\mbrkBinSub0
-\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo4\dy26\hr14\min23}{\version51}{\edmins554}{\nofpages24}{\nofwords7588}
+\rsid9243658\rsid9252303\rsid9512169\rsid9838801\rsid10101060\rsid10161515\rsid10290913\rsid10902102\rsid10945524\rsid11337799\rsid11370278\rsid11430143\rsid11488686\rsid11602030\rsid11865833\rsid12197314\rsid12343757\rsid12792789\rsid12848963
+\rsid12856395\rsid12916989\rsid13005600\rsid13133162\rsid13725463\rsid13791374\rsid13858952\rsid13987238\rsid14176547\rsid14566444\rsid14697282\rsid14893653\rsid15166704\rsid15355254\rsid16005803\rsid16010693\rsid16670594}{\mmathPr\mmathFont34\mbrkBin0
+\mbrkBinSub0\msmallFrac0\mdispDef1\mlMargin0\mrMargin0\mdefJc1\mwrapIndent1440\mintLim0\mnaryLim1}{\info{\operator Carl Webster}{\creatim\yr2014\mo1\dy27\hr9\min47}{\revtim\yr2020\mo4\dy28\hr13\min36}{\version52}{\edmins555}{\nofpages24}{\nofwords7588}
 {\nofchars43258}{\nofcharsws50745}{\vern127}}{\*\xmlnstbl {\xmlns1 http://schemas.microsoft.com/office/word/2003/wordml}}\paperw12240\paperh15840\margl1440\margr1440\margt1440\margb1440\gutter0\ltrsect 
 \widowctrl\ftnbj\aenddoc\trackmoves0\trackformatting1\donotembedsysfont0\relyonvml0\donotembedlingdata1\grfdocevents0\validatexml0\showplaceholdtext0\ignoremixedcontent0\saveinvalidxml0\showxmlerrors0\horzdoc\dghspace120\dgvspace120\dghorigin1701
 \dgvorigin1984\dghshow0\dgvshow3\jcompress\viewkind1\viewscale113\rsidroot11488686 \fet0{\*\wgrffmtfilter 2450}\ilfomacatclnup0{\*\docvar {__Grammarly_42____i}{H4sIAAAAAAAEAKtWckksSQxILCpxzi/NK1GyMqwFAAEhoTITAAAA}}
@@ -203,7 +203,7 @@ lowing languages:
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f2\fs22\insrsid8013811 \hich\af2\dbch\af31505\loch\f2 o\tab}\hich\af31506\dbch\af31505\loch\f31506 Groups with AdminCount=1}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 
 \f31506\fs22\insrsid8013811\charrsid10290913 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid10290913\charrsid10290913 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}}\pard \ltrpar\ql \fi-360\li720\ri0\nowidctlpar\wrapdefault\faauto\ls4\rin0\lin720\itap0\pararsid10290913 {
-\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 Group Policies by Domain
+\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 \hich\af31506\dbch\af31505\loch\f31506 Group Policies \hich\af31506\dbch\af31505\loch\f31506 by Domain
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid10290913\charrsid10290913 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Group Policies by Organizational Unit}{\rtlch\fcs1 \af0\afs22 
 \ltrch\fcs0 \f31506\fs22\insrsid1520287 \hich\af31506\dbch\af31505\loch\f31506  }{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid10290913\charrsid10290913 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f3\fs22\insrsid10290913\charrsid10290913 \loch\af3\dbch\af31505\hich\f3 \'b7\tab}\hich\af31506\dbch\af31505\loch\f31506 Miscellaneous Data by Domain
@@ -215,7 +215,7 @@ lowing languages:
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}{\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f31506\fs22\insrsid2974686 \hich\af31506\dbch\af31505\loch\f31506 Disabled users
 
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Unknown users
-\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Locked\hich\af31506\dbch\af31505\loch\f31506  out users
+\par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 Locked out users
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}\hich\af31506\dbch\af31505\loch\f31506 All users with password expired
 \par {\listtext\pard\plain\ltrpar \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f10\fs22\insrsid2974686\charrsid2974686 \loch\af10\dbch\af31505\hich\f10 \'a7\tab}}\pard \ltrpar
 \ql \fi-360\li2160\ri0\nowidctlpar\wrapdefault\faauto\ls4\ilvl2\rin0\lin2160\itap0\pararsid2974686 {\rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid2974686\charrsid2974686 \hich\af37\dbch\af31505\loch\f37 All users whose password never expires}{
@@ -273,19 +273,19 @@ At least one Windows 7 SP1 or later computer with the Remote Server Administrati
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 
  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=7887" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9200000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff000060000030000000003a00}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0000000000006301000000000000080963000000040000000000000000650000ff000060000030000000003a0000}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 7 with Service Pack 1 (SP1)}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 b.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d0146d0e0001000098000066}}}{\fldrslt {\rtlch\fcs1 
-\af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administratio\hich\af37\dbch\af31505\loch\f37 n Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab000000000000560000000000004200000000000b00000000002d00000000000041d0146d0e000100009800006600}}}{\fldrslt {\rtlch\fcs1 
+\af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administrati\hich\af37\dbch\af31505\loch\f37 on Tools for Windows 8}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37 c.\tab}\hich\af37\dbch\af31505\loch\f37 RSAT for Windows 8.1 is available here, }{\field{\*\fldinst {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid11602030 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a64006d0000006300c800f672}}}{\fldrslt {\rtlch\fcs1 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab00006449000000000000000017000000000000240000000000000000002200003a64006d0000006300c800f67270}}}{\fldrslt {\rtlch\fcs1 
 \af37\afs22 \ltrch\fcs0 \cs18\f37\fs22\ul\cf2\insrsid11602030\charrsid11602030 \hich\af37\dbch\af31505\loch\f37 Remote Server Administration Tools for Windows 8.1}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid11602030 \hich\af37\dbch\af31505\loch\f37   
 \par {\listtext\pard\plain\ltrpar \s17 \rtlch\fcs1 \af0\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37 d.\tab}}\pard \ltrpar\s17\ql \fi-360\li1440\ri0\sa200\sl276\slmult1
@@ -293,7 +293,7 @@ At least one Windows 7 SP1 or later computer with the Remote Server Administrati
 {\field\fldedit{\*\fldinst {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952 \hich\af37\dbch\af31505\loch\f37  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 
 \f37\fs22\insrsid12916989 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c000000000036000002}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003ff00000000000009007300000000000000000000000000000063002c00000000003600000289}}}{\fldrslt {\rtlch\fcs1 \af37\afs22 
 \ltrch\fcs0 \cs18\fs22\ul\cf1\insrsid13858952 \hich\af43\dbch\af31505\loch\f43 Remote Server Administration Tools for Windows 10}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid13858952\charrsid13858952 
 
 \par }\pard \ltrpar\s17\ql \li0\ri0\sa200\sl276\slmult1\nowidctlpar\wrapdefault\faauto\rin0\lin0\itap0\pararsid10290913\contextualspace {\rtlch\fcs1 \af37\afs22 \ltrch\fcs0 \f37\fs22\insrsid10290913 
@@ -432,7 +432,7 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     Creates a complete inventory of a Microsoft Active Directory Forest using Microsoft
 \par \hich\af2\dbch\af31505\loch\f2     PowerShell, Word, plain text}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7488809 ,}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2  or HTML.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text or HTML file named after\hich\af2\dbch\af31505\loch\f2  the Active Directory Forest.
+\par \hich\af2\dbch\af31505\loch\f2     Creates a Word or PDF document, text or HTML file named afte\hich\af2\dbch\af31505\loch\f2 r the Active Directory Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Word and PDF document includes a Cover Page, Table of Contents and Footer.
 \par \hich\af2\dbch\af31505\loch\f2     Includes support for the following language versions of Microsoft Word:
@@ -440,7 +440,7 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         Chinese
 \par \hich\af2\dbch\af31505\loch\f2         Danish
 \par \hich\af2\dbch\af31505\loch\f2         Dutch
-\par \hich\af2\dbch\af31505\loch\f2         E\hich\af2\dbch\af31505\loch\f2 nglish
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 English
 \par \hich\af2\dbch\af31505\loch\f2         Finnish
 \par \hich\af2\dbch\af31505\loch\f2         French
 \par \hich\af2\dbch\af31505\loch\f2         German
@@ -477,28 +477,28 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=7887" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9200000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004a}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
+65007400610069006c0073002e0061007300700078003f00690064003d0037003800380037000000795881f43b1d7f48af2c825dc485276300000000a5ab0003004a00}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=7887}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=28972" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab00030080}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
+65007400610069006c0073002e0061007300700078003f00690064003d00320038003900370032000000795881f43b1d7f48af2c825dc485276300000000a5ab0003008000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details\hich\af2\dbch\af31505\loch\f2 .aspx?id=28972}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 8.1
 \par \hich\af2\dbch\af31505\loch\f2         }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=39296" }{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006e}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
+65007400610069006c0073002e0061007300700078003f00690064003d00330039003200390036000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006e08}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/details.aspx?id=39296}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Remote Server Administration Tools for Windows 10
 \par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 
  HYPERLINK "http://www.microsoft.com/en-us/download/details.aspx?id=45520" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b9400000068007400740070003a002f002f007700770077002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f0064006f0077006e006c006f00610064002f006400
-65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab00030065}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
+65007400610069006c0073002e0061007300700078003f00690064003d00340035003500320030000000795881f43b1d7f48af2c825dc485276300000000a5ab0003006500}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 
 \hich\af2\dbch\af31505\loch\f2 http://www.microsoft.com/en-us/download/det\hich\af2\dbch\af31505\loch\f2 ails.aspx?id=45520}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par 
@@ -613,31 +613,31 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2                 Integral (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Ion (Dark) (Word 2013/2016. Top date doesn't fit; box needs to be
 \par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fit; box needs to be
-\par \hich\af2\dbch\af31505\loch\f2                 manually resiz\hich\af2\dbch\af31505\loch\f2 ed or font changed to 8 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Ion (Light) (Word 2013/2016. Top date doesn't fi\hich\af2\dbch\af31505\loch\f2 t; box needs to be
+\par \hich\af2\dbch\af31505\loch\f2                 manually resized or font changed to 8 point)
 \par \hich\af2\dbch\af31505\loch\f2                 Mod (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Motion (Word 2010/2013/2016. Works if top date is manually changed to
 \par \hich\af2\dbch\af31505\loch\f2                 36 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Newsprint (Word 2010. Works but date is not populated)
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2              Perspective (Word 2010. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 Newsprint\hich\af2\dbch\af31505\loch\f2  (Word 2010. Works but date is not populated)
+\par \hich\af2\dbch\af31505\loch\f2                 Perspective (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Pinstripes (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Puzzle (Word 2010. Top date doesn't fit; box needs to be manually
-\par \hich\af2\dbch\af31505\loch\f2                 resized or font changed to 14 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Wor\hich\af2\dbch\af31505\loch\f2 d 2013/2016. Works)
+\par \hich\af2\dbch\af31505\loch\f2                 resized or font cha\hich\af2\dbch\af31505\loch\f2 nged to 14 point)
+\par \hich\af2\dbch\af31505\loch\f2                 Retrospect (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Semaphore (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Sideline (Word 2010/2013/2016. Doesn't work in 2013 or 2016, works in
 \par \hich\af2\dbch\af31505\loch\f2                 2010)
-\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) (Word 2013/2016. Doesn't work)
-\par \hich\af2\dbch\af31505\loch\f2                 Sl\hich\af2\dbch\af31505\loch\f2 ice (Light) (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Dark) \hich\af2\dbch\af31505\loch\f2 (Word 2013/2016. Doesn't work)
+\par \hich\af2\dbch\af31505\loch\f2                 Slice (Light) (Word 2013/2016. Doesn't work)
 \par \hich\af2\dbch\af31505\loch\f2                 Stacks (Word 2010. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Tiles (Word 2010. Date doesn't fit unless changed to 26 point)
-\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works)
-\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Wor\hich\af2\dbch\af31505\loch\f2 ks)
+\par \hich\af2\dbch\af31505\loch\f2                 Transcend (Word 2010. Works\hich\af2\dbch\af31505\loch\f2 )
+\par \hich\af2\dbch\af31505\loch\f2                 ViewMaster (Word 2013/2016. Works)
 \par \hich\af2\dbch\af31505\loch\f2                 Whisp (Word 2013/2016. Works)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         The default value is Sideline.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of CP.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parame\hich\af2\dbch\af31505\loch\f2 ters.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -646,26 +646,26 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UserName <String>
-\par \hich\af2\dbch\af31505\loch\f2         Userna\hich\af2\dbch\af31505\loch\f2 me to use for the Cover Page and Footer.
+\par \hich\af2\dbch\af31505\loch\f2         Username to use for the Cover Page and Footer.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is contained in $env:username
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of UN.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid with the MSWORD and PDF output parameters.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is only valid wi\hich\af2\dbch\af31505\loch\f2 th the MSWORD and PDF output parameters.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $env:username
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters\hich\af2\dbch\af31505\loch\f2 ?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -HTML [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .htm\hich\af2\dbch\af31505\loch\f2 l extension.
+\par \hich\af2\dbch\af31505\loch\f2         Creates an HTML file with an .html extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value       \hich\af2\dbch\af31505\loch\f2          False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard\hich\af2\dbch\af31505\loch\f2  characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MSWord [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs DOCX file
@@ -675,27 +675,27 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         A\hich\af2\dbch\af31505\loch\f2 ccept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -PDF [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         SaveAs PDF file instead of DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter is disabled by default.
-\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires Microsoft Word to be installed.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
-\par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?      \hich\af2\dbch\af31505\loch\f2               false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
-\par 
-\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text \hich\af2\dbch\af31505\loch\f2 file with a .txt extension.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         The PDF file is roughly 5X to 10X larger than the DOCX file.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter require\hich\af2\dbch\af31505\loch\f2 s Microsoft Word to be installed.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter uses the Word SaveAs PDF capability.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?  \hich\af2\dbch\af31505\loch\f2      false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par 
+\par \hich\af2\dbch\af31505\loch\f2     -Text [<SwitchParameter>]
+\par \hich\af2\dbch\af31505\loch\f2         Creates a formatted text file with a .txt extension.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par 
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
@@ -703,26 +703,26 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds a date time stamp to the end of the file name.
 \par \hich\af2\dbch\af31505\loch\f2         The timestamp is in the format of yyyy-MM-dd_HHmm.
-\par \hich\af2\dbch\af31505\loch\f2         June \hich\af2\dbch\af31505\loch\f2 1, 2020 at 6PM is 2020-06-01_1800.
+\par \hich\af2\dbch\af31505\loch\f2         June 1, 2020 at 6PM is 2020-06-01_1800.
 \par \hich\af2\dbch\af31505\loch\f2         Output filename will be ReportName_2020-06-01_1800.docx (or .pdf).
-\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This p\hich\af2\dbch\af31505\loch\f2 arameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Defa\hich\af2\dbch\af31505\loch\f2 ult value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -ADForest <String>
+\par \hich\af2\dbch\af31505\loch\f2     -A\hich\af2\dbch\af31505\loch\f2 DForest <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory forest object by providing one of the following
 \par \hich\af2\dbch\af31505\loch\f2         attribute values.
-\par \hich\af2\dbch\af31505\loch\f2    \hich\af2\dbch\af31505\loch\f2      The identifier in parentheses is the LDAP display name for the attribute.
+\par \hich\af2\dbch\af31505\loch\f2         The identifier in parentheses is the LDAP display name for the attribute.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Fully qualified domain name
-\par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2         Example: labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par \hich\af2\dbch\af31505\loch\f2                 Example: 599c3d2e-e61e-4d20-7b77-030d99495e19
-\par \hich\af2\dbch\af31505\loch\f2         DNS\hich\af2\dbch\af31505\loch\f2  host name
+\par \hich\af2\dbch\af31505\loch\f2         DNS host name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2         NetBIOS name
 \par \hich\af2\dbch\af31505\loch\f2                 Example: labaddomain
@@ -733,14 +733,14 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?   \hich\af2\dbch\af31505\loch\f2     false
+\par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:US\hich\af2\dbch\af31505\loch\f2 ERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ADDomain <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies an Active Directory domain object by providing one of the following
-\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in parentheses is the LDAP display name for the
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2    attribute. All values are for the domainDNS object that represents the domain.
+\par \hich\af2\dbch\af31505\loch\f2         property values. The identifier in paren\hich\af2\dbch\af31505\loch\f2 theses is the LDAP display name for the
+\par \hich\af2\dbch\af31505\loch\f2         attribute. All values are for the domainDNS object that represents the domain.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Distinguished Name
 \par 
@@ -748,9 +748,9 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         GUID (objectGUID)
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Example: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
+\par \hich\af2\dbch\af31505\loch\f2         Exam\hich\af2\dbch\af31505\loch\f2 ple: b9fa5fbd-4334-4a98-85f1-3a3a44069fc6
 \par 
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Security Identifier (objectSid)
+\par \hich\af2\dbch\af31505\loch\f2         Security Identifier (objectSid)
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Example: S-1-5-21-3643273344-1505409314-3732760578
 \par 
@@ -765,77 +765,77 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         If both ADForest and ADDomain are specified, ADDomain takes precedence.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?         \hich\af2\dbch\af31505\loch\f2            named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard \hich\af2\dbch\af31505\loch\f2 characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies which domain controller to use to run the script against.
-\par \hich\af2\dbch\af31505\loch\f2         If ADForest is a trusted forest, then ComputerName is required to detect the
+\par \hich\af2\dbch\af31505\loch\f2         If ADForest is a tr\hich\af2\dbch\af31505\loch\f2 usted forest, then ComputerName is required to detect the
 \par \hich\af2\dbch\af31505\loch\f2         existence of ADForest.
-\par \hich\af2\dbch\af31505\loch\f2         ComputerN\hich\af2\dbch\af31505\loch\f2 ame can be entered as the NetBIOS name, FQDN, localhost or IP Address.
-\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and used.
+\par \hich\af2\dbch\af31505\loch\f2         ComputerName can be entered as the NetBIOS name, FQDN, localhost or IP Address.
+\par \hich\af2\dbch\af31505\loch\f2         If entered as localhost, the actual computer name is determined and use\hich\af2\dbch\af31505\loch\f2 d.
 \par \hich\af2\dbch\af31505\loch\f2         If entered as an IP address, an attempt is made to determine and use the actual
-\par \hich\af2\dbch\af31505\loch\f2         compute\hich\af2\dbch\af31505\loch\f2 r name.
+\par \hich\af2\dbch\af31505\loch\f2         computer name.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of ServerName.
 \par \hich\af2\dbch\af31505\loch\f2         Default value is $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                $Env:USERDNSDOMAIN
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -DCDNSInfo [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather, for each domain controller, the IP Address, and eac\hich\af2\dbch\af31505\loch\f2 h DNS server
+\par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather, for each domain controller, the IP Address, and each DNS server
 \par \hich\af2\dbch\af31505\loch\f2         configured.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardwa\hich\af2\dbch\af31505\loch\f2 re information (i.e. Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
-\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter w\hich\af2\dbch\af31505\loch\f2 ill add an extra section to the report.
+\par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add an extra section to the report.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       fa\hich\af2\dbch\af31505\loch\f2 lse
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Folder <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional output folder to save the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                   \hich\af2\dbch\af31505\loch\f2  false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -GPOInheritance [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         In the Group Policies by OU section, adds Inherited GPOs in addition to the GPOs
+\par \hich\af2\dbch\af31505\loch\f2         In the Grou\hich\af2\dbch\af31505\loch\f2 p Policies by OU section, adds Inherited GPOs in addition to the GPOs
 \par \hich\af2\dbch\af31505\loch\f2         directly linked.
 \par \hich\af2\dbch\af31505\loch\f2         Adds a second column to the table GPO Type.
 \par \hich\af2\dbch\af31505\loch\f2         The text file is placed in the same folder from where the script is run.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is d\hich\af2\dbch\af31505\loch\f2 isabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of GPO.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wild\hich\af2\dbch\af31505\loch\f2 card characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Hardware [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Use WMI to gather hardware information on Computer System, Disks, Processor, and
 \par \hich\af2\dbch\af31505\loch\f2         Network Interface Cards
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an\hich\af2\dbch\af31505\loch\f2  elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShel\hich\af2\dbch\af31505\loch\f2 l session
 \par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve hardware information (i.e. Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   This parameter is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is\hich\af2\dbch\af31505\loch\f2  disabled by default.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -848,28 +848,28 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         and DistinguishedName of the users in the All Users counts:
 \par 
 \par \hich\af2\dbch\af31505\loch\f2                 Disabled users
-\par \hich\af2\dbch\af31505\loch\f2                 Unknown users
+\par \hich\af2\dbch\af31505\loch\f2                 Unknown use\hich\af2\dbch\af31505\loch\f2 rs
 \par \hich\af2\dbch\af31505\loch\f2                 Locked out users
 \par \hich\af2\dbch\af31505\loch\f2                 All users with password expired
-\par \hich\af2\dbch\af31505\loch\f2                 All users whose password neve\hich\af2\dbch\af31505\loch\f2 r expires
+\par \hich\af2\dbch\af31505\loch\f2                 All users whose password never expires
 \par \hich\af2\dbch\af31505\loch\f2                 All users with password not required
 \par \hich\af2\dbch\af31505\loch\f2                 All users who cannot change password
-\par \hich\af2\dbch\af31505\loch\f2                 All users with SID History
+\par \hich\af2\dbch\af31505\loch\f2            \hich\af2\dbch\af31505\loch\f2      All users with SID History
 \par \hich\af2\dbch\af31505\loch\f2                 All users with Homedrive set in ADUC
-\par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Grou\hich\af2\dbch\af31505\loch\f2 p is not Domain Users
+\par \hich\af2\dbch\af31505\loch\f2                 All users whose Primary Group is not Domain Users
 \par \hich\af2\dbch\af31505\loch\f2                 All users with RDS HomeDrive set in ADUC
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited to the first 25 characters of the SamAccountName
+\par \hich\af2\dbch\af31505\loch\f2         The Text output option is limited to th\hich\af2\dbch\af31505\loch\f2 e first 25 characters of the SamAccountName
 \par \hich\af2\dbch\af31505\loch\f2         and the first 116 characters of the DistinguishedName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         This paramete\hich\af2\dbch\af31505\loch\f2 r is disabled by default.
+\par \hich\af2\dbch\af31505\loch\f2         This parameter is disabled by default.
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of IU.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Positi\hich\af2\dbch\af31505\loch\f2 on?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept\hich\af2\dbch\af31505\loch\f2  wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -MaxDetails [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Adds maximum detail to the report.
@@ -881,24 +881,24 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2                 IncludeUserInfo
 \par \hich\af2\dbch\af31505\loch\f2                 Services
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         WARNING: Using this parameter can create an extremely large report and
+\par \hich\af2\dbch\af31505\loch\f2         WARN\hich\af2\dbch\af31505\loch\f2 ING: Using this parameter can create an extremely large report and
 \par \hich\af2\dbch\af31505\loch\f2         can take a very long time to run.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter has an alias of MAX.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default\hich\af2\dbch\af31505\loch\f2  value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Services [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Gath\hich\af2\dbch\af31505\loch\f2 er information on all services running on domain controllers.
-\par \hich\af2\dbch\af31505\loch\f2         Servers that are configured to automatically start but are not running will be
+\par \hich\af2\dbch\af31505\loch\f2         Gather information on all services running on domain controllers.
+\par \hich\af2\dbch\af31505\loch\f2         Servers that are configur\hich\af2\dbch\af31505\loch\f2 ed to automatically start but are not running will be
 \par \hich\af2\dbch\af31505\loch\f2         colored in red.
 \par \hich\af2\dbch\af31505\loch\f2         Used on Domain Controllers only.
-\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script\hich\af2\dbch\af31505\loch\f2  be run from an elevated PowerShell session
-\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retrieve service information (i.e. Domain
+\par \hich\af2\dbch\af31505\loch\f2         This parameter requires the script be run from an elevated PowerShell session
+\par \hich\af2\dbch\af31505\loch\f2         using an account with permission to retriev\hich\af2\dbch\af31505\loch\f2 e service information (i.e. Domain
 \par \hich\af2\dbch\af31505\loch\f2         Admin).
 \par \hich\af2\dbch\af31505\loch\f2         Selecting this parameter will add to both the time it takes to run the script and
 \par \hich\af2\dbch\af31505\loch\f2         size of the report.
@@ -906,26 +906,26 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2     Default value                False
+\par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
-\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
+\par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters? \hich\af2\dbch\af31505\loch\f2  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -Section <Array>
 \par \hich\af2\dbch\af31505\loch\f2         Processes one or more sections of the report.
 \par \hich\af2\dbch\af31505\loch\f2         Valid options are:
 \par \hich\af2\dbch\af31505\loch\f2                 Forest
-\par \hich\af2\dbch\af31505\loch\f2      \hich\af2\dbch\af31505\loch\f2            Sites
+\par \hich\af2\dbch\af31505\loch\f2                 Sites
 \par \hich\af2\dbch\af31505\loch\f2                 Domains (includes Domain Controllers and optional Hardware, Services and
-\par \hich\af2\dbch\af31505\loch\f2                 DCDNSInfo)
+\par \hich\af2\dbch\af31505\loch\f2             \hich\af2\dbch\af31505\loch\f2     DCDNSInfo)
 \par \hich\af2\dbch\af31505\loch\f2                 OUs (Organizational Units)
 \par \hich\af2\dbch\af31505\loch\f2                 Groups
 \par \hich\af2\dbch\af31505\loch\f2                 GPOs
-\par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous \hich\af2\dbch\af31505\loch\f2 data)
+\par \hich\af2\dbch\af31505\loch\f2                 Misc (Miscellaneous data)
 \par \hich\af2\dbch\af31505\loch\f2                 All
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This parameter defaults to All sections.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated by a comma. -Section forest, domains
+\par \hich\af2\dbch\af31505\loch\f2         Multiple sections are separated b\hich\af2\dbch\af31505\loch\f2 y a comma. -Section forest, domains
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
@@ -936,27 +936,27 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the optional email server to send the output report.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?              \hich\af2\dbch\af31505\loch\f2       true
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort <Int32>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the SMTP port.
 \par \hich\af2\dbch\af31505\loch\f2         The default is 25.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Re\hich\af2\dbch\af31505\loch\f2 quired?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
-\par \hich\af2\dbch\af31505\loch\f2         Default value                25
+\par \hich\af2\dbch\af31505\loch\f2         \hich\af2\dbch\af31505\loch\f2 Default value                25
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL [<SwitchParameter>]
-\par \hich\af2\dbch\af31505\loch\f2         Specifies whe\hich\af2\dbch\af31505\loch\f2 ther to use SSL for the SmtpServer.
+\par \hich\af2\dbch\af31505\loch\f2         Specifies whether to use SSL for the SmtpServer.
 \par \hich\af2\dbch\af31505\loch\f2         The default is False.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?                    false
+\par \hich\af2\dbch\af31505\loch\f2         Required?\hich\af2\dbch\af31505\loch\f2                     false
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value                False
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
@@ -966,25 +966,25 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the From email address.
 \par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2         Required?            \hich\af2\dbch\af31505\loch\f2         true
+\par \hich\af2\dbch\af31505\loch\f2         Required?                    true
 \par \hich\af2\dbch\af31505\loch\f2         Position?                    named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
-\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
+\par \hich\af2\dbch\af31505\loch\f2         Accept pipeline inpu\hich\af2\dbch\af31505\loch\f2 t?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -To <String>
 \par \hich\af2\dbch\af31505\loch\f2         Specifies the username for the To email address.
-\par \hich\af2\dbch\af31505\loch\f2         If SmtpSe\hich\af2\dbch\af31505\loch\f2 rver is used, this is a required parameter.
+\par \hich\af2\dbch\af31505\loch\f2         If SmtpServer is used, this is a required parameter.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Required?                    true
-\par \hich\af2\dbch\af31505\loch\f2         Position?                    named
+\par \hich\af2\dbch\af31505\loch\f2         Position?  \hich\af2\dbch\af31505\loch\f2                   named
 \par \hich\af2\dbch\af31505\loch\f2         Default value
 \par \hich\af2\dbch\af31505\loch\f2         Accept pipeline input?       false
 \par \hich\af2\dbch\af31505\loch\f2         Accept wildcard characters?  false
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -Dev [<Switch\hich\af2\dbch\af31505\loch\f2 Parameter>]
+\par \hich\af2\dbch\af31505\loch\f2     -Dev [<SwitchParameter>]
 \par \hich\af2\dbch\af31505\loch\f2         Clears errors at the beginning of the script.
-\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text file at the end of the script.
+\par \hich\af2\dbch\af31505\loch\f2         Outputs all errors to a text fil\hich\af2\dbch\af31505\loch\f2 e at the end of the script.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         This is used when the script developer requests more troubleshooting data.
 \par \hich\af2\dbch\af31505\loch\f2         The\hich\af2\dbch\af31505\loch\f2  text file is placed in the same folder from where the script is run.
@@ -1039,7 +1039,7 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2         VERSION: 2.2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7488809 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par \hich\af2\dbch\af31505\loch\f2         AUTHOR: Carl Webster and Michael B. Smith
 \par \hich\af2\dbch\af31505\loch\f2         L\hich\af2\dbch\af31505\loch\f2 ASTEDIT: }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 April }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid13005600 
-\hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid7488809 \hich\af2\dbch\af31505\loch\f2 6}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 , 2020}{\rtlch\fcs1 \af2\afs18 
+\hich\af2\dbch\af31505\loch\f2 2}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid10161515 \hich\af2\dbch\af31505\loch\f2 8}{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 , 2020}{\rtlch\fcs1 \af2\afs18 
 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 1 --------------------------
@@ -1408,19 +1408,19 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -PDF -ADForest corp.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -AddDateTime
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all defau\hich\af2\dbch\af31505\loch\f2 lt values and save the document as a PDF file.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Will use all default values and save the document as a PDF file.
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_US\hich\af2\dbch\af31505\loch\f2 ER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
-\par \hich\af2\dbch\af31505\loch\f2     $env:username = Admi\hich\af2\dbch\af31505\loch\f2 nistrator
+\par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
-\par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
+\par \hich\af2\dbch\af31505\loch\f2     Sideline for\hich\af2\dbch\af31505\loch\f2  the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script querie\hich\af2\dbch\af31505\loch\f2 s for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server\hich\af2\dbch\af31505\loch\f2  and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Adds a date time stamp to the end of the file name.
@@ -1433,25 +1433,25 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 18 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSSc\hich\af2\dbch\af31505\loch\f2 ript >.\\ADDS_Inventory_V2.ps1 -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest corp.carlwebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -Folder \\\\FileServer\\ShareName
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Softwa\hich\af2\dbch\af31505\loch\f2 re\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
+\par \hich\af2\dbch\af31505\loch\f2     C\hich\af2\dbch\af31505\loch\f2 arl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2  \hich\af2\dbch\af31505\loch\f2    ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
+\par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
+\par \hich\af2\dbch\af31505\loch\f2     a doma\hich\af2\dbch\af31505\loch\f2 in controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The output file will be saved in the path \\\\File\hich\af2\dbch\af31505\loch\f2 Server\\ShareName.
+\par \hich\af2\dbch\af31505\loch\f2     The output file will be saved in the path \\\\FileServer\\ShareName.
 \par 
 \par 
 \par 
@@ -1461,42 +1461,42 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -Section Forest
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\\hich\af2\dbch\af31505\loch\f2 UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webster" or
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     Webste\hich\af2\dbch\af31505\loch\f2 r" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
-\par \hich\af2\dbch\af31505\loch\f2     Administ\hich\af2\dbch\af31505\loch\f2 rator for the User Name.
+\par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     ADForest defaults to the value of $Env:USERDNSDOMAIN
+\par \hich\af2\dbch\af31505\loch\f2     ADFores\hich\af2\dbch\af31505\loch\f2 t defaults to the value of $Env:USERDNSDOMAIN
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ComputerName defaults to the value of $Env:USERDNSDOMAIN, then the script queries for
-\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as \hich\af2\dbch\af31505\loch\f2 the
+\par \hich\af2\dbch\af31505\loch\f2     a domain controller that is also a global catalog server and will use that as the
 \par \hich\af2\dbch\af31505\loch\f2     value for ComputerName.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The report will include only the Forest section.
+\par \hich\af2\dbch\af31505\loch\f2     \hich\af2\dbch\af31505\loch\f2 The report will include only the Forest section.
 \par 
 \par 
 \par 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 20 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\\hich\af2\dbch\af31505\loch\f2 ADDS_Inventory_V2.ps1 -Section groups, misc
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -Section groups, misc
 \par \hich\af2\dbch\af31505\loch\f2     -ADForest WebstersLab.com -ServerName PrimaryDC.websterslab.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CUR\hich\af2\dbch\af31505\loch\f2 RENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\U\hich\af2\dbch\af31505\loch\f2 serInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com for ADFore\hich\af2\dbch\af31505\loch\f2 st.
-\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.websterslab.com for ComputerName.
+\par \hich\af2\dbch\af31505\loch\f2     WebstersLab.com for ADForest.
+\par \hich\af2\dbch\af31505\loch\f2     PrimaryDC.websterslab.com for Comput\hich\af2\dbch\af31505\loch\f2 erName.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The report will include only the Groups and Miscellaneous sections.
 \par 
@@ -1508,7 +1508,7 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -MaxDetails
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
-\par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
+\par \hich\af2\dbch\af31505\loch\f2     HKEY_CU\hich\af2\dbch\af31505\loch\f2 RRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
 \par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
@@ -1520,8 +1520,8 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     Set the following parameter values:
 \par \hich\af2\dbch\af31505\loch\f2         DCDNSInfo       = True
 \par \hich\af2\dbch\af31505\loch\f2         GPOInheritance  = True
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2       Hardware        = True
-\par \hich\af2\dbch\af31505\loch\f2         IncludeUserInfo = True
+\par \hich\af2\dbch\af31505\loch\f2         Hardware        = True
+\par \hich\af2\dbch\af31505\loch\f2       \hich\af2\dbch\af31505\loch\f2   IncludeUserInfo = True
 \par \hich\af2\dbch\af31505\loch\f2         Services        = True
 \par 
 \par \hich\af2\dbch\af31505\loch\f2         Section         = "All"
@@ -1531,28 +1531,28 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 22 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest corp\hich\af2\dbch\af31505\loch\f2 .carlwebster.com
-\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mail.domain.tld
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1 -ADForest corp.carlwebster.com
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer ma\hich\af2\dbch\af31505\loch\f2 il.domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -From XDAdmin@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -ComputerName Server01
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Will use all Default values.
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\CompanyName="Carl
-\par \hich\af2\dbch\af31505\loch\f2     Webs\hich\af2\dbch\af31505\loch\f2 ter" or
+\par \hich\af2\dbch\af31505\loch\f2     Webster" or
 \par \hich\af2\dbch\af31505\loch\f2     HKEY_CURRENT_USER\\Software\\Microsoft\\Office\\Common\\UserInfo\\Company="Carl Webster"
 \par \hich\af2\dbch\af31505\loch\f2     $env:username = Administrator
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     Carl Webster for the Company Name.
 \par \hich\af2\dbch\af31505\loch\f2     Sideline for the Cover Page format.
 \par \hich\af2\dbch\af31505\loch\f2     Administrator for the User Name.
-\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebster.com for the AD Forest.
+\par \hich\af2\dbch\af31505\loch\f2     corp.carlwebst\hich\af2\dbch\af31505\loch\f2 er.com for the AD Forest.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will be run remotely against server Server01.
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server mail.domain.tld, sending from XDAdmin@domain.tld,
-\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup\hich\af2\dbch\af31505\loch\f2 @domain.tld.
+\par \hich\af2\dbch\af31505\loch\f2     sending to ITGroup@domain.tld.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will not use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP \hich\af2\dbch\af31505\loch\f2 port 25 and will not use SSL.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     If the current user's credentials are not valid to send email,
 \par \hich\af2\dbch\af31505\loch\f2     the user will be prompted to enter valid credentials.
@@ -1560,9 +1560,9 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par 
 \par 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23\hich\af2\dbch\af31505\loch\f2  --------------------------
+\par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 23 --------------------------
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1
+\par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS\hich\af2\dbch\af31505\loch\f2 _Inventory_V2.ps1
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer mailrelay.domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -From Anonymous@domain.tld
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@domain.tld
@@ -1581,16 +1581,16 @@ Forest <String>] [-ADDomain <String>] [-ComputerName <String>] }{\rtlch\fcs1 \af
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/2956491?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7c000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0032003900350036003400
-390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 
+390031003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab00030000e3}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/2956491?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://support.google.com/a/answer/176600?hl=en" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 
 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b7a000000680074007400700073003a002f002f0073007500700070006f00720074002e0067006f006f0067006c0065002e0063006f006d002f0061002f0061006e0073007700650072002f0031003700360036003000
-30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300d0}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 
+30003f0068006c003d0065006e000000795881f43b1d7f48af2c825dc485276300000000a5ab000300d000}}}{\fldrslt {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 
 https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     To send email using a Gmail or g-suite account, you may have to turn ON
-\par \hich\af2\dbch\af31505\loch\f2     the "Less secure app access" option on your account.
+\par \hich\af2\dbch\af31505\loch\f2     the\hich\af2\dbch\af31505\loch\f2  "Less secure app access" option on your account.
 \par \hich\af2\dbch\af31505\loch\f2     ***GMAIL/G SUITE SMTP RELAY***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will generate an anonymous secure password for the anonymous@domain.tld
@@ -1602,29 +1602,29 @@ https://support.google.com/a/answer/176600?hl=en}}}\sectd \ltrsect\linex0\sectde
 \par \hich\af2\dbch\af31505\loch\f2     -------------------------- EXAMPLE 24 --------------------------
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1
-\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -SmtpServer labaddomain-com.mail.protection.outlook.com
+\par \hich\af2\dbch\af31505\loch\f2     -SmtpServer labaddomain-com.mail.protection.outlook.com
 \par \hich\af2\dbch\af31505\loch\f2     -UseSSL
 \par \hich\af2\dbch\af31505\loch\f2     -From SomeEmailAddress@labaddomain.com
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroupDL@labaddomain.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2  HYPERLINK "https://docs.micro\hich\af2\dbch\af31505\loch\f2 
-soft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
+\par \hich\af2\dbch\af31505\loch\f2     }{\field{\*\fldinst {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 \hich\af2\dbch\af31505\loch\f2 
+ HYPERLINK "https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3" }{\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650 {\*\datafield 
 00d0c9ea79f9bace118c8200aa004ba90b0200000003000000e0c9ea79f9bace118c8200aa004ba90b40010000680074007400700073003a002f002f0064006f00630073002e006d006900630072006f0073006f00660074002e0063006f006d002f0065006e002d00750073002f00650078006300680061006e0067006500
 2f006d00610069006c002d0066006c006f0077002d0062006500730074002d007000720061006300740069006300650073002f0068006f0077002d0074006f002d007300650074002d00750070002d0061002d006d0075006c0074006900660075006e006300740069006f006e002d006400650076006900630065002d006f
-0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab00030031}}}{\fldrslt {\rtlch\fcs1 
-\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-email-using-office-3}
-}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
+0072002d006100700070006c00690063006100740069006f006e002d0074006f002d00730065006e0064002d0065006d00610069006c002d007500730069006e0067002d006f00660066006900630065002d0033000000795881f43b1d7f48af2c825dc485276300000000a5ab0003003100}}}{\fldrslt {\rtlch\fcs1 
+\af2\afs18 \ltrch\fcs0 \cs18\f2\fs18\ul\cf2\insrsid4338650\charrsid4338650 \hich\af2\dbch\af31505\loch\f2 https://docs.microsoft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-device-or-application-to-send-emai
+\hich\af2\dbch\af31505\loch\f2 l-using-office-3}}}\sectd \ltrsect\linex0\sectdefaultcl\sftnbj {\rtlch\fcs1 \af2\afs18 \ltrch\fcs0 \f2\fs18\insrsid4338650\charrsid4338650 
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     This \hich\af2\dbch\af31505\loch\f2 uses Option 2 from the above link.
+\par \hich\af2\dbch\af31505\loch\f2     This uses Option 2 from the above link.
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     ***OFFICE 365 Example***
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server labaddomain-com.mail.protection.outlook.com,
-\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@labaddomain.com.
+\par \hich\af2\dbch\af31505\loch\f2     sending from SomeEmailAddress@labaddomain.com, sending to ITGroupDL@la\hich\af2\dbch\af31505\loch\f2 baddomain.com.
 \par 
-\par \hich\af2\dbch\af31505\loch\f2     The script\hich\af2\dbch\af31505\loch\f2  will use the default SMTP port 25 and will use SSL.
+\par \hich\af2\dbch\af31505\loch\f2     The script will use the default SMTP port 25 and will use SSL.
 \par 
 \par 
 \par 
@@ -1634,8 +1634,8 @@ soft.com/en-us/exchange/mail-flow-best-practices/how-to-set-up-a-multifunction-d
 \par \hich\af2\dbch\af31505\loch\f2     PS C:\\PSScript >.\\ADDS_Inventory_V2.ps1
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpServer smtp.office365.com
 \par \hich\af2\dbch\af31505\loch\f2     -SmtpPort 587
-\par \hich\af2\dbch\af31505\loch\f2     -UseSSL
-\par \hich\af2\dbch\af31505\loch\f2     -From Webster@Ca\hich\af2\dbch\af31505\loch\f2 rlWebster.com
+\par \hich\af2\dbch\af31505\loch\f2   \hich\af2\dbch\af31505\loch\f2   -UseSSL
+\par \hich\af2\dbch\af31505\loch\f2     -From Webster@CarlWebster.com
 \par \hich\af2\dbch\af31505\loch\f2     -To ITGroup@CarlWebster.com
 \par 
 \par \hich\af2\dbch\af31505\loch\f2     The script will use the email server smtp.office365.com on port 587 using SSL,
@@ -1788,8 +1788,8 @@ fffffffffffffffffdfffffffeffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
 ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
-ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000c0ff
-ee20001cd601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
+ffffffffffffffffffffffffffffffff52006f006f007400200045006e00740072007900000000000000000000000000000000000000000000000000000000000000000000000000000000000000000016000500ffffffffffffffffffffffff0c6ad98892f1d411a65f0040963251e5000000000000000000000000a057
+06e08b1dd601feffffff00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff00000000000000000000000000000000000000000000000000000000
 00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000
 000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000ffffffffffffffffffffffff000000000000000000000000000000000000000000000000
 0000000000000000000000000000000000000000000000000105000000000000}}

--- a/ADDS_Script_ChangeLog.txt
+++ b/ADDS_Script_ChangeLog.txt
@@ -9,11 +9,13 @@
 #https://www.essential.exchange/blog/
 #
 
-#Version 2.26
+#Version 2.26 28-Apr-2020
 #	Add checking for a Word version of 0, which indicates the Office installation needs repairing
 #	Add Receive Side Scaling setting to Function OutputNICItem
+#	Change location of the -Dev, -Log, and -ScriptInfo output files from the script folder to the -Folder location (Thanks to Guy Leech for the "suggestion")
 #	Change Text output to use [System.Text.StringBuilder]
 #		Updated Functions Line and SaveAndCloseTextDocument
+#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
 #	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
 
 #Version 2.25 21-Apr-2020

--- a/ADDS_Script_ChangeLog.txt
+++ b/ADDS_Script_ChangeLog.txt
@@ -9,6 +9,13 @@
 #https://www.essential.exchange/blog/
 #
 
+#Version 2.26
+#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
+#	Add Receive Side Scaling setting to Function OutputNICItem
+#	Change Text output to use [System.Text.StringBuilder]
+#		Updated Functions Line and SaveAndCloseTextDocument
+#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
+
 #Version 2.25 21-Apr-2020
 #	Remove the SMTP parameterset and manually verify the parameters
 #	Reorder parameters


### PR DESCRIPTION
#Version 2.26 28-Apr-2020
#	Add checking for a Word version of 0, which indicates the Office installation needs repairing
#	Add Receive Side Scaling setting to Function OutputNICItem
#	Change location of the -Dev, -Log, and -ScriptInfo output files from the script folder to the -Folder location (Thanks to Guy Leech for the "suggestion")
#	Change Text output to use [System.Text.StringBuilder]
#		Updated Functions Line and SaveAndCloseTextDocument
#	Reformatted the terminating Write-Error messages to make them more visible and readable in the console
#	Update Functions GetComputerWMIInfo and OutputNicInfo to fix two bugs in NIC Power Management settings
